### PR TITLE
Separate parsing of a path

### DIFF
--- a/applications/DG-Max/DGMaxProgramUtils.cpp
+++ b/applications/DG-Max/DGMaxProgramUtils.cpp
@@ -117,10 +117,14 @@ namespace DGMax
                 throw std::invalid_argument("Not enough coordinates for a reciprocal point");
             }
             std::size_t len = 0;
-            point[i] = std::stod(pointString.substr(start), &len);
-            if(len == 0)
+            try
             {
-                throw std::invalid_argument("No value parsed");
+                point[i] = std::stod(pointString.substr(start), &len);
+            }
+            catch (const std::invalid_argument&)
+            {
+                // No parse, i.e. len == 0
+                throw std::invalid_argument("Number point parsing failed at '" + pointString.substr(start) + "', expected a coordinate");
             }
             start += len;
             if(i < DIM - 1)

--- a/applications/DG-Max/DGMaxProgramUtils.cpp
+++ b/applications/DG-Max/DGMaxProgramUtils.cpp
@@ -100,5 +100,79 @@ namespace DGMax
     template
     std::unique_ptr<Base::MeshManipulator<3>> readMesh(std::string, Base::ConfigurationData*, ElementInfos::EpsilonFunc<3>);
 
+    /// Parse DIM comma separated numbers as the coordinates of a point.
+    /// \tparam DIM The dimension of the point
+    /// \param pointString The string containing the point coordinates
+    /// \param start The starting index in pointString
+    /// \param point The point (out)
+    /// \return The first index in pointString after the number.
+    template<std::size_t DIM>
+    std::size_t parsePoint(const std::string& pointString, std::size_t start,
+                           LinearAlgebra::SmallVector<DIM>& point)
+    {
+        for(std::size_t i = 0; i < DIM; ++i)
+        {
+            if(start >= pointString.size())
+            {
+                throw std::invalid_argument("Not enough coordinates for a reciprocal point");
+            }
+            std::size_t len = 0;
+            point[i] = std::stod(pointString.substr(start), &len);
+            if(len == 0)
+            {
+                throw std::invalid_argument("No value parsed");
+            }
+            start += len;
+            if(i < DIM - 1)
+            {
+                // Skip the comma, space, whatever that ended the point
+                start++;
+            }
+        }
+        return start;
+    }
 
+    template<std::size_t DIM>
+    PointPath<DIM> parsePath(const std::string& path)
+    {
+        LinearAlgebra::SmallVector<DIM> point;
+        std::size_t index = 0; // Current parsing index
+
+        int steps = -1;
+        // Check if the string starts with number@, to denote step count
+        std::size_t atIndex = path.find_first_of('@');
+        if(atIndex != std::string::npos)
+        {
+            std::size_t len = 0;
+            steps = std::stoul(path, &len);
+            index = atIndex + 1; // Start parsing points after the @
+            if(len != atIndex)
+            {
+                throw std::invalid_argument("Left between number of steps and '@'");
+            }
+        }
+
+        // Parse a string of points
+        std::vector<LinearAlgebra::SmallVector<DIM>> points;
+        while(index < path.length())
+        {
+            LinearAlgebra::SmallVector<DIM> point;
+            index = parsePoint(path, index, point);
+            points.push_back(point);
+            // Strip character if needed
+            while (index < path.length()
+                   && (std::isspace(path[index])  // Allow spaces, just as sto*-functions
+                       || path[index] == ':')) // Allow colon separation for readability
+            {
+                index++;
+            }
+        }
+        return PointPath<DIM>(points, steps);
+    }
+
+    // Explicit instantiation
+
+    template PointPath<1> parsePath(const std::string& path);
+    template PointPath<2> parsePath(const std::string& path);
+    template PointPath<3> parsePath(const std::string& path);
 }

--- a/applications/DG-Max/DGMaxProgramUtils.h
+++ b/applications/DG-Max/DGMaxProgramUtils.h
@@ -27,6 +27,35 @@ namespace DGMax
     std::unique_ptr<Base::MeshManipulator<DIM>>
             readMesh(std::string fileName, Base::ConfigurationData *configData,
                     ElementInfos::EpsilonFunc<DIM> epsilonFunc);
+
+
+    /// A path in either real or reciprocal space
+    template<std::size_t DIM>
+    struct PointPath
+    {
+        /// The points along the path
+        std::vector<LinearAlgebra::SmallVector<DIM>> points_;
+        /// Possible number of steps specified to take to that point, default -1
+        /// if not specified
+        int steps_;
+
+        PointPath(std::vector<LinearAlgebra::SmallVector<DIM>> points, int steps = -1)
+                : points_ (points), steps_(steps)
+        {}
+    };
+
+    /// \brief Parse a path description
+    /// Parse a path, a path follows the syntax
+    ///    path = (steps '@')? point (':' point)*
+    ///    point = coord (',' coord){dim-1}, where dim is the dimension
+    ///    coord = double (
+    ///    steps = unsigned integer
+    /// Thus a 2D path may look like 20@1,0:1,1 meaning two points 1,0 and 1,1 with 20 steps
+    /// \tparam DIM The dimensionality of the path
+    /// \param path The path string to parse
+    /// \return The points on the path
+    template<std::size_t DIM>
+    PointPath<DIM> parsePath(const std::string& path);
 }
 
 #endif //HPGEM_PROGRAMUTILS_H

--- a/applications/DG-Max/Programs/DGMaxEigen.cpp
+++ b/applications/DG-Max/Programs/DGMaxEigen.cpp
@@ -150,48 +150,24 @@ KSpacePath<DIM> parsePath()
 {
     if(pointMode.isUsed())
     {
-        const std::string& pointString = pointMode.getValue();
-        typename KSpacePath<DIM>::KPoint point;
-        std::size_t index = 0; // Current parsing index
-
-        std::size_t steps = 1;
-        // Check if the string starts with number@, to denote step count
-        std::size_t atIndex = pointString.find_first_of('@');
-        if(atIndex != std::string::npos)
+        DGMax::PointPath<DIM> path = DGMax::parsePath<DIM>(pointMode.getValue());
+        // Make single point mode easier by automatically inserting 0,0 at the start
+        if(path.points_.size() == 1)
         {
-            std::size_t len = 0;
-            steps = std::stoul(pointString, &len);
-            index = atIndex + 1; // Start parsing points after the @
-            if(len != atIndex)
-            {
-                throw std::invalid_argument("Left between number of steps and '@'");
-            }
+            path.points_.emplace_back(path.points_[0]);
+            path.points_[0] *= 0;
         }
-
-        // Parse a string of points
-        std::vector<LinearAlgebra::SmallVector<DIM>> points;
-        while(index < pointString.length())
+        // Compensate for factor of pi in the reciprocal lattice
+        for(std::size_t i = 0; i < path.points_.size(); ++i)
         {
-            LinearAlgebra::SmallVector<DIM> point;
-            index = parsePoint(pointString, index, point);
-            point *= M_PI; // Treat it as reduced point
-            points.push_back(point);
-            // Strip character if needed
-            while (index < pointString.length()
-                && (std::isspace(pointString[index])  // Allow spaces, just as sto*-functions
-                   || pointString[index] == ':')) // Allow colon separation for readability
-            {
-                index++;
-            }
+            path.points_[i] *= M_PI;
         }
-        // Simplify single point mode.
-        if(points.size() == 1)
+        // Default steps to 1.
+        if(path.steps_ < 0)
         {
-            points.emplace_back(points[0]);
-            points[0] *= 0;
+            path.steps_ = 1;
         }
-
-        return KSpacePath<DIM>(points, steps);
+        return KSpacePath<DIM>(path.points_, (std::size_t) path.steps_);
     }
     else
     {


### PR DESCRIPTION
The path specification could be used in multiple programs (e.g. a
plotter for theoretical band diagrams). It should therefore not reside
in DGMaxEigen.