### PR TITLE
Dgmax in dgmaxeigen

### DIFF
--- a/applications/DG-Max/Algorithms/DGMaxEigenValue.cpp
+++ b/applications/DG-Max/Algorithms/DGMaxEigenValue.cpp
@@ -28,6 +28,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 #include <petscmat.h>
 #include <petscvec.h>
 #include <slepceps.h>
+#include <DGMaxLogger.h>
 
 #include "Base/MeshManipulator.h"
 #include "LinearAlgebra/SmallVector.h"
@@ -97,7 +98,6 @@ typename DGMaxEigenValue<DIM>::Result DGMaxEigenValue<DIM>::solve(
     PetscErrorCode error;
     EPS eigenSolver = createEigenSolver();
 
-    std::cout << "finding a bunch of eigenvalues" << std::endl;
     int measureAmount = 0;
 
     //For IP-DG solving a general eigenproblem is slightly faster,
@@ -109,12 +109,12 @@ typename DGMaxEigenValue<DIM>::Result DGMaxEigenValue<DIM>::solve(
 
     Utilities::GlobalPetscMatrix massMatrix(&mesh_, DGMaxDiscretization<DIM>::MASS_MATRIX_ID, -1),
             stiffnessMatrix(&mesh_, DGMaxDiscretization<DIM>::STIFFNESS_MATRIX_ID, DGMaxDiscretization<DIM>::FACE_MATRIX_ID);
-    std::cout << "GlobalPetscMatrix initialised" << std::endl;
+    DGMaxLogger(INFO, "GlobalPetscMatrix initialised");
     Utilities::GlobalPetscVector
             sampleGlobalVector(&mesh_, -1, -1);
-    std::cout << "GlobalPetscVector initialised" << std::endl;
+    DGMaxLogger(INFO, "GlobalPetscVector initialised");
     sampleGlobalVector.assemble();
-    std::cout << "sampleGlobalVector assembled" << std::endl;
+    DGMaxLogger(INFO, "sampleGlobalVector assembled");
 
     Mat product;
     error = MatMatMult(massMatrix, stiffnessMatrix, MAT_INITIAL_MATRIX, 1.0, &product);
@@ -129,10 +129,6 @@ typename DGMaxEigenValue<DIM>::Result DGMaxEigenValue<DIM>::solve(
     error = EPSSetDimensions(eigenSolver, numberOfEigenvalues, PETSC_DEFAULT, PETSC_DEFAULT);
     CHKERRABORT(PETSC_COMM_WORLD, error);
 
-    // Setup is done, solve for the eigenvalues.
-    error = EPSSolve(eigenSolver);
-    CHKERRABORT(PETSC_COMM_WORLD, error);
-
     // Setup eigen vector storage
     Vec *eigenVectors = new Vec[numberOfEigenVectors];
     error = VecDuplicateVecs(sampleGlobalVector, numberOfEigenVectors, &eigenVectors);
@@ -145,10 +141,6 @@ typename DGMaxEigenValue<DIM>::Result DGMaxEigenValue<DIM>::solve(
     CHKERRABORT(PETSC_COMM_WORLD, error);
     error = VecSetUp(waveVec);
     CHKERRABORT(PETSC_COMM_WORLD, error);
-
-    LinearAlgebra::SmallVector<DIM> dk = kpath.dk(1);
-
-    makeShiftMatrix(mesh_, massMatrix.getGlobalIndex(), dk, waveVec);
     error = VecDuplicate(waveVec, &waveVecConjugate);
     CHKERRABORT(PETSC_COMM_WORLD, error);
     error = VecCopy(waveVec, waveVecConjugate);
@@ -185,22 +177,17 @@ typename DGMaxEigenValue<DIM>::Result DGMaxEigenValue<DIM>::solve(
     // Last id used for offsetting leftNumber/rightNumber
     PetscInt lastLeftOffset = 0, lastRightOffset = 0;
 
+    LinearAlgebra::SmallVector<DIM> dk; // Step in k-space from previous solve
     std::size_t maxStep = kpath.totalNumberOfSteps();
-    // For testing
-    // maxStep = 21;
 
     std::vector<std::vector<PetscScalar>> eigenvalues (maxStep);
 
-    extractEigenValues(eigenSolver, eigenvalues[0]);
-    // extractEigenValues removes all zero eigen values. This is not correct for
-    // k = 0, where 0 is a physically interesting eigenvalue.
-    eigenvalues[0].insert(eigenvalues[0].begin(), 0);
-
-    for (int i = 1; i < maxStep; ++i)
+    for (int i = 0; i < maxStep; ++i)
     {
-        std::cout << "Computing eigenvalues for k-point " << i << std::endl;
+        DGMaxLogger(INFO, "Computing eigenvalues for k-point %/%", i+1, maxStep);
         if (kpath.dkDidChange(i))
         {
+
             dk = kpath.dk(i);
             //recompute the shifts
             makeShiftMatrix(mesh_, massMatrix.getGlobalIndex(), dk, waveVec);
@@ -209,8 +196,16 @@ typename DGMaxEigenValue<DIM>::Result DGMaxEigenValue<DIM>::solve(
             error = VecConjugate(waveVecConjugate);
             CHKERRABORT(PETSC_COMM_WORLD, error);
         }
-        error = EPSGetInvariantSubspace(eigenSolver, eigenVectors);
-        CHKERRABORT(PETSC_COMM_WORLD, error);
+        int converged;
+        if (i > 0)
+        {
+            // Extract solutions from previous iteration, needs to be done before
+            // changing the matrices for the new k-vector.
+            error = EPSGetInvariantSubspace(eigenSolver, eigenVectors);
+            CHKERRABORT(PETSC_COMM_WORLD, error);
+            error = EPSGetConverged(eigenSolver, &converged);
+            CHKERRABORT(PETSC_COMM_WORLD, error);
+        }
         error = MatDiagonalScale(product, waveVec, waveVecConjugate);
         CHKERRABORT(PETSC_COMM_WORLD, error);
 
@@ -274,13 +269,14 @@ typename DGMaxEigenValue<DIM>::Result DGMaxEigenValue<DIM>::solve(
             measureAmount++;
         }
 
-        int converged;
-        error = EPSGetConverged(eigenSolver, &converged);
-        CHKERRABORT(PETSC_COMM_WORLD, error);
         error = EPSSetOperators(eigenSolver, product, NULL);
         CHKERRABORT(PETSC_COMM_WORLD, error);
-        error = EPSSetInitialSpace(eigenSolver, converged, eigenVectors);
-        CHKERRABORT(PETSC_COMM_WORLD, error);
+        if (i > 0)
+        {
+            // Use solution of previous time as starting point for the next one.
+            error = EPSSetInitialSpace(eigenSolver, converged, eigenVectors);
+            CHKERRABORT(PETSC_COMM_WORLD, error);
+        }
         error = EPSSetUp(eigenSolver);
         CHKERRABORT(PETSC_COMM_WORLD, error);
         error = EPSSolve(eigenSolver);

--- a/applications/DG-Max/Algorithms/DGMaxEigenValue.cpp
+++ b/applications/DG-Max/Algorithms/DGMaxEigenValue.cpp
@@ -185,7 +185,7 @@ typename DGMaxEigenValue<DIM>::Result DGMaxEigenValue<DIM>::solve(
     // Last id used for offsetting leftNumber/rightNumber
     PetscInt lastLeftOffset = 0, lastRightOffset = 0;
 
-    std::size_t maxStep = kpath.totalNumberOfSteps() + 1;
+    std::size_t maxStep = kpath.totalNumberOfSteps();
     // For testing
     // maxStep = 21;
 
@@ -270,7 +270,7 @@ typename DGMaxEigenValue<DIM>::Result DGMaxEigenValue<DIM>::solve(
         //outputs 'old' data
         if (i % 20 == 1)
         {
-            sampleGlobalVector.writeTimeIntegrationVector(measureAmount);
+            //sampleGlobalVector.writeTimeIntegrationVector(measureAmount);
             measureAmount++;
         }
 
@@ -294,7 +294,7 @@ typename DGMaxEigenValue<DIM>::Result DGMaxEigenValue<DIM>::solve(
     error = EPSGetInvariantSubspace(eigenSolver, eigenVectors);
     CHKERRABORT(PETSC_COMM_WORLD, error);
 
-    sampleGlobalVector.writeTimeIntegrationVector(measureAmount);
+    //sampleGlobalVector.writeTimeIntegrationVector(measureAmount);
 
     error = VecDestroy(&waveVec);
     CHKERRABORT(PETSC_COMM_WORLD, error);

--- a/applications/DG-Max/Algorithms/DivDGMaxEigenValue.cpp
+++ b/applications/DG-Max/Algorithms/DivDGMaxEigenValue.cpp
@@ -175,9 +175,9 @@ typename DivDGMaxEigenValue<DIM>::Result DivDGMaxEigenValue<DIM>::solve(
     std::vector<std::vector<PetscScalar>> eigenvalues (maxSteps);
 
     DGMaxLogger(INFO, "Starting k-vector walk");
-    for (int i = 1; i < maxSteps; ++i)
+    for (int i = 0; i < maxSteps; ++i)
     {
-        DGMaxLogger(INFO, "Solving for k-vector %/%", i, maxSteps-1);
+        DGMaxLogger(INFO, "Solving for k-vector %/%", i+1, maxSteps);
 
         if(kpath.dkDidChange(i))
         {
@@ -297,7 +297,7 @@ typename DivDGMaxEigenValue<DIM>::Result DivDGMaxEigenValue<DIM>::solve(
             error = EPSSetInitialSpace(eigenSolver, converged, eigenVectors);
             CHKERRABORT(PETSC_COMM_WORLD, error);
         }
-        DGMaxLogger(INFO, "Setting up solve for k-vector %/%", i, maxSteps-1);
+        DGMaxLogger(INFO, "Setting up solve for k-vector %/%", i+1, maxSteps);
         error = EPSSetUp(eigenSolver);
         CHKERRABORT(PETSC_COMM_WORLD, error);
 
@@ -307,7 +307,7 @@ typename DivDGMaxEigenValue<DIM>::Result DivDGMaxEigenValue<DIM>::solve(
         //EPSSetFromOptions(eigenSolver_);
         //CHKERRABORT(PETSC_COMM_WORLD);
 
-        DGMaxLogger(INFO, "Solving for k-vector %/%", i, maxSteps-1);
+        DGMaxLogger(INFO, "Solving for k-vector %/%", i+1, maxSteps);
         error = EPSSolve(eigenSolver);
         CHKERRABORT(PETSC_COMM_WORLD, error);
 

--- a/applications/DG-Max/Programs/DGMaxEigen.cpp
+++ b/applications/DG-Max/Programs/DGMaxEigen.cpp
@@ -5,6 +5,7 @@
 #include "DGMaxLogger.h"
 #include "DGMaxProgramUtils.h"
 #include "Algorithms/DivDGMaxEigenValue.h"
+#include "Algorithms/DGMaxEigenValue.h"
 
 
 // File name of the mesh file, e.g. -m mesh.hpgem
@@ -16,6 +17,10 @@ auto& p = Base::register_argument<std::size_t>('p', "order",
 // Number of eigenvalues to compute, e.g. -e 40
 auto& numEigenvalues = Base::register_argument<std::size_t>('e', "eigenvalues",
         "The number of eigenvalues to compute", false, 24);
+
+auto& method = Base::register_argument<std::string>('\0', "method",
+        "The method to be used, either 'DGMAX' or 'DIVDGMAX' (default)",
+        false, "DIVDGMAX");
 
 // Compute a single point --point 1,0.5,0 or a path of points
 // [steps@]0,0:1,0:1,1
@@ -46,6 +51,7 @@ auto& structure = Base::register_argument<std::size_t>('\0', "structure",
 
 template<std::size_t DIM>
 void runWithDimension();
+double parseDGMaxPenaltyParameter();
 template<std::size_t DIM>
 typename DivDGMaxDiscretization<DIM>::Stab parsePenaltyParmaters();
 template<std::size_t DIM>
@@ -93,24 +99,53 @@ int main(int argc, char** argv)
 template<std::size_t DIM>
 void runWithDimension()
 {
-    typename DivDGMaxDiscretization<DIM>::Stab stab = parsePenaltyParmaters<DIM>();
-
+    bool useDivDGMax;
     // 2 unknowns, 1 time level
-    Base::ConfigurationData configData(2, 1);
+    if (method.getValue() == "DGMAX")
+    {
+        useDivDGMax = false;
+    }
+    else if (method.getValue() == "DIVDGMAX")
+    {
+        useDivDGMax = true;
+    }
+    else
+    {
+        logger(ERROR, "Invalid method {}, should be either DGMAX or DIVDGMAX", method.getValue());
+        return;
+    }
+
+    Base::ConfigurationData configData(useDivDGMax ? 2 : 1, 1);
     auto mesh = DGMax::readMesh<DIM>(meshFile.getValue(), &configData, [&](const Geometry::PointPhysical<DIM>& p) {
         // TODO: Hardcoded structure
         return jelmerStructure(p, structure.getValue());
     });
     logger(INFO, "Loaded mesh % with % local elements", meshFile.getValue(), mesh->getNumberOfElements());
-    DivDGMaxEigenValue<DIM> solver(*mesh);
     // TODO: Parameterize
     KSpacePath<DIM> path = parsePath<DIM>();
     EigenValueProblem<DIM> input(path, numEigenvalues.getValue());
-    typename DivDGMaxEigenValue<DIM>::Result result = solver.solve(input, stab, p.getValue());
-    if (Base::MPIContainer::Instance().getProcessorID() == 0)
+    // Method dependent solving
+    if (useDivDGMax)
     {
-        result.printFrequencies();
-        result.writeFrequencies("frequencies.csv");
+        DivDGMaxEigenValue<DIM> solver(*mesh);
+        typename DivDGMaxDiscretization<DIM>::Stab stab = parsePenaltyParmaters<DIM>();
+        typename DivDGMaxEigenValue<DIM>::Result result = solver.solve(input, stab, p.getValue());
+        if (Base::MPIContainer::Instance().getProcessorID() == 0)
+        {
+            result.printFrequencies();
+            result.writeFrequencies("frequencies.csv");
+        }
+    }
+    else
+    {
+        DGMaxEigenValue<DIM> solver (*mesh, p.getValue());
+        const double stab = parseDGMaxPenaltyParameter();
+        typename DGMaxEigenValue<DIM>::Result result = solver.solve(input, stab);
+        if (Base::MPIContainer::Instance().getProcessorID() == 0)
+        {
+            result.printFrequencies();
+            result.writeFrequencies("frequencies.csv");
+        }
     }
 }
 
@@ -200,6 +235,32 @@ KSpacePath<DIM> parsePath()
             logger(INFO, "Using default number of steps %", steps.getValue());
         }
         return KSpacePath<DIM>::cubePath(steps.getValue(), false);
+    }
+}
+
+double parseDGMaxPenaltyParameter()
+{
+    if (pparams.isUsed())
+    {
+        std::size_t idx;
+        try
+        {
+            double value = std::stod(pparams.getValue(), &idx);
+            if (idx != pparams.getValue().size())
+            {
+                throw std::invalid_argument("Invalid stabilization parameter, should be a single number for DGMAX");
+            }
+            return value;
+        }
+        catch (const std::invalid_argument&)
+        {
+            throw std::invalid_argument("Invalid stabilization parameter, should be a single number for DGMAX");
+        }
+    }
+    else
+    {
+        // Default
+        return 100;
     }
 }
 

--- a/applications/DG-Max/Programs/DGMaxEigen.cpp
+++ b/applications/DG-Max/Programs/DGMaxEigen.cpp
@@ -186,12 +186,6 @@ KSpacePath<DIM> parsePath()
     if(pointMode.isUsed())
     {
         DGMax::PointPath<DIM> path = DGMax::parsePath<DIM>(pointMode.getValue());
-        // Make single point mode easier by automatically inserting 0,0 at the start
-        if(path.points_.size() == 1)
-        {
-            path.points_.emplace_back(path.points_[0]);
-            path.points_[0] *= 0;
-        }
         // Compensate for factor of pi in the reciprocal lattice
         for(std::size_t i = 0; i < path.points_.size(); ++i)
         {

--- a/applications/DG-Max/Utils/KSpacePath.cpp
+++ b/applications/DG-Max/Utils/KSpacePath.cpp
@@ -51,7 +51,7 @@ LinearAlgebra::SmallVector<DIM> KSpacePath<DIM>::dk(std::size_t index) const
 template <std::size_t DIM>
 bool KSpacePath<DIM>::dkDidChange(std::size_t index) const
 {
-    logger.assert_debug(index != 0, "dk is not valid at -1 or 0");
+    logger.assert_always(index < totalNumberOfSteps(), "Index {} larger than total number of steps ", index, totalNumberOfSteps());
     // When arriving at point a point for indices 0, steps_, 2steps_, etc.
     // so at 1, steps_ +1, 2steps_ + 1 we change direction. Additionally
     // for index == 0 dk is not valid, so we mark it as changed
@@ -74,8 +74,8 @@ typename KSpacePath<DIM>::KPoint KSpacePath<DIM>::kcorner(std::size_t index) con
 template <std::size_t DIM>
 KSpacePath<DIM> KSpacePath<DIM>::singleStepPath(KSpacePath<DIM>::KPoint point)
 {
-    std::vector<KSpacePath<DIM>::KPoint> points (2);
-    points[1] = point;
+    std::vector<KSpacePath<DIM>::KPoint> points (1);
+    points[0] = point;
     KSpacePath<DIM> path (points, 1);
     return path;
 }


### PR DESCRIPTION
Update DGMaxEigen to allow using both the DGMax and DivDGMax discretization using the --method flag.

Additionally, the difference that DivDGMax did not compute the eigenvalues of the first k-point and DGMax did, has been removed by letting them both compute the eigenvalues at the first point.