### PR TITLE
Fix an off-by-one issue in GlobalIndexing

### DIFF
--- a/kernel/Utilities/GlobalIndexing.cpp
+++ b/kernel/Utilities/GlobalIndexing.cpp
@@ -313,9 +313,9 @@ namespace Utilities
                 std::size_t mpiOffset = globalOffset[rank];
 
                 offsets[unknown].setOffset(mpiOffset, localBaseOffset, numberOfBasisFunctions[unknown]);
-                // globalOffset[n+1] contains the sum of all the basis functions for
+                // globalOffset[n] contains the sum of all the basis functions for
                 // this unknown plus those for previous unknowns.
-                baseOffset = globalOffset[n + 1];
+                baseOffset = globalOffset[n];
                 localBaseOffset += numberOfBasisFunctions[unknown];
             }
         }


### PR DESCRIPTION
The last element of the list is at index n when there are n-entries for the procesors and an extra one at the start.

Fixes #10 