### PR TITLE
Fix changing basis functions for mixed formulation

### DIFF
--- a/kernel/Base/Element.h
+++ b/kernel/Base/Element.h
@@ -87,6 +87,11 @@ namespace Base
         void setGaussQuadratureRule(QuadratureRules::GaussQuadratureRule * const quadR);
 
         void setDefaultBasisFunctionSet(std::size_t position) {
+            // Clear all unknowns so that no old data is left from previous basis
+            // function configurations.
+            for(std::size_t unknown = 0; unknown < getNumberOfUnknowns(); ++unknown) {
+                basisFunctions_.clearBasisFunctionPosition(unknown);
+            }
             for(std::size_t unknown = 0; unknown < getNumberOfUnknowns(); ++unknown) {
                 setDefaultBasisFunctionSet(position, unknown);
             }

--- a/tests/self/Basic/070ChangeOfBasisFunctions_SelfTest.cpp
+++ b/tests/self/Basic/070ChangeOfBasisFunctions_SelfTest.cpp
@@ -51,10 +51,14 @@ int main(int argc, char** argv)
     using namespace std::string_literals;
     Base::parse_options(argc, argv);
     //this test should also be effective in 1D , but 2D has 3x as much 'wrong' basis functions for only a little extra effort
-    Base::ConfigurationData* config = new Base::ConfigurationData(1);
+    // Note, only using the first unknown of the 2, but having multiple to see nothing fails when having multiple
+    // unknowns.
+    Base::ConfigurationData* config = new Base::ConfigurationData(2);
     Base::MeshManipulator<2> mesh(config);
     mesh.readMesh(Base::getCMAKE_hpGEM_SOURCE_DIR() + "/tests/files/"s  + "2Dminimalmesh.hpgem"s);
     mesh.useDefaultDGBasisFunctions(1);
+    // Use different BF for the second unknown.
+    mesh.useDefaultConformingBasisFunctions(1,1);
     for(Base::Element* element : mesh.getElementsList())
     {
         element->setNumberOfTimeIntegrationVectors(1);


### PR DESCRIPTION
When using a scheme with multiple unknowns where at least one has a different type of basis function, calling `use***BasisFunctions(order)`, the one without the unknown-parameter, would crash. The cause was that the basis functions would be deleted at the start of the method, when setting the basis function on each element through `setDefaultBasisFunctionSet(position, unknown)` it would do so unknown by unknown. When setting the first unknown only the information of the first unknown would be cleared, the out-dated information for the other unknowns would remain. As the code for setting the basis function also updates the quadrature rules, it tried to determine the maximum order of these old basis functions. As these were already deleted the code did crash.

The fix here is to start by clearing all the information from old basis functions. This is not ideal as it is also done again by `setDefaultBasisFunctionSet(position, unknown)`, but the easiest fix for this probably uncommon situation.