### PR TITLE
Improved matrix entry estimate code

### DIFF
--- a/kernel/Base/CMakeLists.txt
+++ b/kernel/Base/CMakeLists.txt
@@ -57,6 +57,7 @@ add_library(hpGEM_Base STATIC
 		${hpGEM_SOURCE_DIR}/kernel/Utilities/GlobalMatrix.cpp
 		${hpGEM_SOURCE_DIR}/kernel/Utilities/GlobalVector.cpp
 		${hpGEM_SOURCE_DIR}/kernel/Utilities/GlobalIndexing.cpp
+		${hpGEM_SOURCE_DIR}/kernel/Utilities/SparsityEstimator.cpp
         GlobalUniqueIndex.cpp ../Utilities/BasisFunctions3DH1ConformingPyramid.cpp)
 
 

--- a/kernel/Base/Edge.cpp
+++ b/kernel/Base/Edge.cpp
@@ -65,7 +65,12 @@ namespace Base
         logger.assert_debug(i < getNumberOfElements(), "Asked for element %, but there are only % elements", i, getNumberOfElements());
         return elements_[i];
     }
-    
+
+    const std::vector<Element*> Edge::getElements() const
+    {
+        return elements_;
+    }
+
     std::vector<Element*> Edge::getElements()
     {
         return elements_;

--- a/kernel/Base/Edge.h
+++ b/kernel/Base/Edge.h
@@ -104,8 +104,9 @@ namespace Base
 
         ///get the root element that is the (indirect) parent of one of the adjacent elements
         const Element* getRootElement() const;
-        
+
         std::vector<Element*> getElements();
+        const std::vector<Element*> getElements() const;
         
         ///\deprecated Does not conform naming conventions, use getEdgeNumber instead
         std::size_t getEdgeNr(std::size_t i)

--- a/kernel/Base/Face.h
+++ b/kernel/Base/Face.h
@@ -90,6 +90,24 @@ namespace Base
         {
             return elementRight_;
         }
+
+        /// Obtain a pointer to the other element of the face.
+        /// \param element A pointer to either the left or right element.
+        /// \return The pointer to the other element.
+        Element* getPtrOtherElement(const Element* element)
+        {
+            logger.assert_debug(element == elementLeft_ || element == elementRight_,
+                    "Not an element to this face");
+            return (element == elementLeft_) ? elementRight_ : elementLeft_;
+        }
+
+        /// see getPtrOtherElement(const Element*)
+        const Element* getPtrOtherElement(const Element* element) const
+        {
+            logger.assert_debug(element == elementLeft_ || element == elementRight_,
+                    "Not an element to this face");
+            return (element == elementLeft_) ? elementRight_ : elementLeft_;
+        }
         
         /// \brief Return the pointer to the element on side iSide.
         const Element* getPtrElement(Side iSide) const

--- a/kernel/Utilities/SparsityEstimator.cpp
+++ b/kernel/Utilities/SparsityEstimator.cpp
@@ -65,7 +65,8 @@ namespace Utilities
 
     void SparsityEstimator::computeSparsityEstimate(
             std::vector<int> &nonZeroPerRowOwned,
-            std::vector<int> &nonZeroPerRowNonOwned) const
+            std::vector<int> &nonZeroPerRowNonOwned,
+            bool includeFaceCoupling) const
     {
         const std::size_t totalNumberOfDoF = indexing_.getNumberOfLocalBasisFunctions();
         const std::size_t nUknowns = indexing_.getNumberOfUnknowns();
@@ -97,12 +98,15 @@ namespace Utilities
             addElementDoFs(element, workspace);
 
             // Face matrix coupling with the element on the other side of the face
-            for(const Base::Face* face : element->getFacesList())
+            if (includeFaceCoupling)
             {
-                if (!face->isInternal())
-                    continue;
-                const Base::Element* other = face->getPtrOtherElement(element);
-                addElementDoFs(other, workspace);
+                for (const Base::Face *face : element->getFacesList())
+                {
+                    if (!face->isInternal())
+                        continue;
+                    const Base::Element *other = face->getPtrOtherElement(element);
+                    addElementDoFs(other, workspace);
+                }
             }
 
             // With all the global indices counted, allocate them.
@@ -124,6 +128,8 @@ namespace Utilities
                 // DoFs from supporting element
                 addElementDoFs(element, workspace);
                 // Face matrix coupling with the element on the other side of the face
+                if (!includeFaceCoupling)
+                    continue;
                 for (const Base::Face* otherFace : element->getFacesList())
                 {
                     if (otherFace == face)
@@ -149,6 +155,8 @@ namespace Utilities
                 // DoFs from supporting element
                 addElementDoFs(element, workspace);
                 // Face matrix coupling with the element on the other side of the face
+                if (!includeFaceCoupling)
+                    continue;
                 for (const Base::Face* face : element->getFacesList())
                 {
                     if (!face->isInternal())
@@ -172,6 +180,8 @@ namespace Utilities
                     // DoFs from the supporting element
                     addElementDoFs(element, workspace);
                     // Face matrix coupling with the element on the other side of the face
+                    if (!includeFaceCoupling)
+                        continue;
                     for (const Base::Face* face : element->getFacesList())
                     {
                         if (!face->isInternal())

--- a/kernel/Utilities/SparsityEstimator.cpp
+++ b/kernel/Utilities/SparsityEstimator.cpp
@@ -1,0 +1,262 @@
+
+#include "SparsityEstimator.h"
+
+#include "Logger.h"
+
+#include "Base/Element.h"
+#include "Base/MeshManipulatorBase.h"
+#include "Utilities/GlobalIndexing.h"
+
+namespace Utilities
+{
+    SparsityEstimator::SparsityEstimator(const Base::MeshManipulatorBase &mesh, const GlobalIndexing &indexing)
+        : mesh_ (mesh)
+        , indexing_ (indexing)
+    {}
+
+    struct SparsityEstimator::Workspace
+    {
+        /// DoFs owned by the current processor
+        std::set<std::size_t> owned;
+        // DoFs not owned by the current processor
+        std::set<std::size_t> notOwned;
+
+        /// Get a reference to either the owned or notOwned DoF set.
+        std::set<std::size_t>& getDoFs(bool owning)
+        {
+            return owning ? owned : notOwned;
+        }
+
+        void clear()
+        {
+            owned.clear();
+            notOwned.clear();
+        }
+    };
+
+    void SparsityEstimator::computeSparsityEstimate(
+            std::vector<int> &nonZeroPerRowOwned,
+            std::vector<int> &nonZeroPerRowNonOwned) const
+    {
+        const std::size_t totalNumberOfDoF = indexing_.getNumberOfLocalBasisFunctions();
+        const std::size_t nUknowns = indexing_.getNumberOfUnknowns();
+        Workspace workspace;
+
+        // Resize and initialize with error data
+        nonZeroPerRowOwned.assign(totalNumberOfDoF, -1);
+        nonZeroPerRowNonOwned.assign(totalNumberOfDoF, -1);
+
+        // To compute the number of non zero's in each row we assume (pessimistically)
+        // that all face matrices are filled. For each DoF we then compute the set of
+        // other DoFs that contribute to at least one face matrix, and counting these
+        // gives the number of non zeros in the row.
+        //
+        // Counting DoFs is done by going over all elements where a basis function has
+        // support. All basis functions with support on these elements can result in non
+        // zero element matrix entries. For non zero face matrix entries we also need to
+        // consider all basis functions that have support on the element adjacent to the
+        // elements where the basis function has support.
+        //
+        // For efficiency purposes we do not traverse each basis function separately,
+        // instead we compute it for all basis functions of a single element/face/etc.
+
+        for (const Base::Element* element : mesh_.getElementsList())
+        {
+            workspace.clear();
+            // Add local basis functions
+            addElementDoFs(element, workspace);
+
+            // Face matrix coupling with the element on the other side of the face
+            for(const Base::Face* face : element->getFacesList())
+            {
+                if (!face->isInternal())
+                    continue;
+                const Base::Element* other = face->getPtrElementLeft() == element
+                                             ? face->getPtrElementRight() : face->getPtrElementLeft();
+                addElementDoFs(other, workspace);
+            }
+
+            // With all the global indices counted, allocate them.
+            for (std::size_t unknown = 0; unknown < nUknowns; ++unknown)
+            {
+                std::size_t offset = indexing_.getGlobalIndex(element, unknown);
+                std::size_t nbasis = element->getLocalNumberOfBasisFunctions(unknown);
+                for (std::size_t i = 0; i < nbasis; ++i)
+                {
+                    nonZeroPerRowOwned[i + offset] = workspace.owned.size();
+                    nonZeroPerRowNonOwned[i + offset] = workspace.notOwned.size();
+                }
+            }
+        }
+        // Faces
+        for (const Base::Face* face : mesh_.getFacesList())
+        {
+            logger.assert_debug(face->isOwnedByCurrentProcessor(), "Face not owned by current processor");
+            workspace.clear();
+            std::vector<const Base::Element*> faceElements = {face->getPtrElementLeft()};
+            if (face->isInternal())
+                faceElements.push_back(face->getPtrElementRight());
+            for (const Base::Element* element : faceElements)
+            {
+                // DoFs from supporting element
+                addElementDoFs(element, workspace);
+                // Face matrix coupling with the element on the other side of the face
+                for (const Base::Face* otherFace : element->getFacesList())
+                {
+                    if (otherFace == face)
+                        continue; // Both left & right element of the original face are already visited
+                    if (!face->isInternal())
+                        continue;
+                    const Base::Element* otherElement = face->getPtrElementLeft() == element
+                                                        ? face->getPtrElementRight() : face->getPtrElementLeft();
+                    // The basis function from the face may couple through any other face of the elements adjacent to
+                    // the face
+                    addElementDoFs(otherElement, workspace);
+                }
+            }
+            // Store the information
+            for (std::size_t unknown = 0; unknown < nUknowns; ++unknown)
+            {
+                const std::size_t offset = indexing_.getGlobalIndex(face, unknown);
+                const std::size_t nbasis = face->getLocalNumberOfBasisFunctions(unknown);
+                for (std::size_t i = 0; i < nbasis; ++i)
+                {
+                    nonZeroPerRowOwned[i + offset] = workspace.owned.size();
+                    nonZeroPerRowNonOwned[i + offset] = workspace.notOwned.size();
+                }
+            }
+        }
+        // Edges
+        for (const Base::Edge* edge : mesh_.getEdgesList())
+        {
+            logger.assert_debug(edge->isOwnedByCurrentProcessor(), "Non owned edge");
+            workspace.clear();
+            for (const Base::Element* element : edge->getElements())
+            {
+                // DoFs from supporting element
+                addElementDoFs(element, workspace);
+                // Face matrix coupling with the element on the other side of the face
+                for (const Base::Face* face : element->getFacesList())
+                {
+                    if (!face->isInternal())
+                        continue;
+                    const Base::Element* otherElement = face->getPtrElementLeft() == element
+                                                        ? face->getPtrElementRight() : face->getPtrElementLeft();
+                    addElementDoFs(otherElement, workspace);
+                }
+            }
+            // Store the information
+            for (std::size_t unknown = 0; unknown < nUknowns; ++unknown)
+            {
+                const std::size_t offset = indexing_.getGlobalIndex(edge, unknown);
+                const std::size_t nbasis = edge->getLocalNumberOfBasisFunctions(unknown);
+                for (std::size_t i = 0; i < nbasis; ++i)
+                {
+                    nonZeroPerRowOwned[i + offset] = workspace.owned.size();
+                    nonZeroPerRowNonOwned[i + offset] = workspace.notOwned.size();
+                }
+            }
+        }
+        // Nodes
+        if (mesh_.dimension() > 1)
+        {
+            for (const Base::Node* node : mesh_.getNodesList())
+            {
+                logger.assert_debug(node->isOwnedByCurrentProcessor(), "Non owned node");
+                workspace.clear();
+                for (const Base::Element* element : node->getElements())
+                {
+                    // DoFs from the supporting element
+                    addElementDoFs(element, workspace);
+                    // Face matrix coupling with the element on the other side of the face
+                    for (const Base::Face* face : element->getFacesList())
+                    {
+                        if (!face->isInternal())
+                            continue;
+                        const Base::Element* otherElement = face->getPtrElementLeft() == element
+                                                            ? face->getPtrElementRight() : face->getPtrElementLeft();
+                        addElementDoFs(otherElement, workspace);
+                    }
+                }
+                // Store the information
+                for (std::size_t unknown = 0; unknown < nUknowns; ++unknown)
+                {
+                    const std::size_t offset = indexing_.getGlobalIndex(node, unknown);
+                    const std::size_t nbasis = node->getLocalNumberOfBasisFunctions(unknown);
+                    for (std::size_t i = 0; i < nbasis; ++i)
+                    {
+                        nonZeroPerRowOwned[i + offset] = workspace.owned.size();
+                        nonZeroPerRowNonOwned[i + offset] = workspace.notOwned.size();
+                    }
+                }
+            }
+        }
+    }
+
+    void SparsityEstimator::addElementDoFs(
+            const Base::Element *element,
+            Workspace &workspace) const
+    {
+        logger.assert_debug(element->isOwnedByCurrentProcessor(), "Element is not owned by processor");
+        const std::size_t unknowns = element->getNumberOfUnknowns();
+        {
+            // For the element
+            std::set<std::size_t> &toChange = workspace.getDoFs(element->isOwnedByCurrentProcessor());
+            for (std::size_t unknown = 0; unknown < unknowns; ++unknown)
+            {
+                const std::size_t offset = indexing_.getGlobalIndex(element, unknown);
+                const std::size_t localBasisFunctions = element->getLocalNumberOfBasisFunctions(unknown);
+                for (std::size_t i = 0; i < localBasisFunctions; ++i)
+                {
+                    toChange.insert(offset + i);
+                }
+            }
+        }
+        // For the faces
+        for (const Base::Face* face : element->getFacesList())
+        {
+            std::set<std::size_t>& toChange = workspace.getDoFs(face->isOwnedByCurrentProcessor());
+            for (std::size_t unknown = 0; unknown < unknowns; ++unknown)
+            {
+                const std::size_t offset = indexing_.getGlobalIndex(face, unknown);
+                const std::size_t localBasisFunctions = face->getLocalNumberOfBasisFunctions(unknown);
+                for (std::size_t i = 0; i < localBasisFunctions; ++i)
+                {
+                    toChange.insert(offset + i);
+                }
+            }
+        }
+        // For the edges
+        for (const Base::Edge* edge : element->getEdgesList())
+        {
+            std::set<std::size_t>& toChange = workspace.getDoFs(edge->isOwnedByCurrentProcessor());
+            for (std::size_t unknown = 0; unknown < unknowns; ++unknown)
+            {
+                const std::size_t offset = indexing_.getGlobalIndex(edge, unknown);
+                const std::size_t localBasisFunctions = edge->getLocalNumberOfBasisFunctions(unknown);
+                for (std::size_t i = 0; i < localBasisFunctions; ++i)
+                {
+                    toChange.insert(offset + i);
+                }
+            }
+        }
+        // For the nodes
+        if (mesh_.dimension() > 1)
+        {
+            // For the edges
+            for (const Base::Node* node : element->getNodesList())
+            {
+                std::set<std::size_t>& toChange = workspace.getDoFs(node->isOwnedByCurrentProcessor());
+                for (std::size_t unknown = 0; unknown < unknowns; ++unknown)
+                {
+                    const std::size_t offset = indexing_.getGlobalIndex(node, unknown);
+                    const std::size_t localBasisFunctions = node->getLocalNumberOfBasisFunctions(unknown);
+                    for (std::size_t i = 0; i < localBasisFunctions; ++i)
+                    {
+                        toChange.insert(offset + i);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/kernel/Utilities/SparsityEstimator.cpp
+++ b/kernel/Utilities/SparsityEstimator.cpp
@@ -128,9 +128,9 @@ namespace Utilities
                 {
                     if (otherFace == face)
                         continue; // Both left & right element of the original face are already visited
-                    if (!face->isInternal())
+                    if (!otherFace->isInternal())
                         continue;
-                    const Base::Element* otherElement = face->getPtrOtherElement(element);
+                    const Base::Element* otherElement = otherFace->getPtrOtherElement(element);
                     // The basis function from the face may couple through any other face of the elements adjacent to
                     // the face
                     addElementDoFs(otherElement, workspace);

--- a/kernel/Utilities/SparsityEstimator.h
+++ b/kernel/Utilities/SparsityEstimator.h
@@ -31,7 +31,10 @@ namespace Utilities
         ///     locally owned basis functions.
         /// \param nonZeroPerRowNonOwned [out] Per local DoF the number of non zero columns
         ///     from non locally owned basis functions.
-        void computeSparsityEstimate(std::vector<int>& nonZeroPerRowOwned, std::vector<int>& nonZeroPerRowNonOwned) const;
+        /// \param includeFaceCoupling [in] Include coupling through face matrices
+        void computeSparsityEstimate(std::vector<int>& nonZeroPerRowOwned,
+                std::vector<int>& nonZeroPerRowNonOwned,
+                bool includeFaceCoupling = true) const;
 
     private:
         /// Workspace variables for the computation

--- a/kernel/Utilities/SparsityEstimator.h
+++ b/kernel/Utilities/SparsityEstimator.h
@@ -1,0 +1,52 @@
+
+#ifndef HPGEM_SPARSITYESTIMATOR_H
+#define HPGEM_SPARSITYESTIMATOR_H
+
+#include "vector"
+
+// Forward definitions
+namespace Base
+{
+    class Element;
+    class MeshManipulatorBase;
+}
+namespace Utilities
+{
+    class GlobalIndexing;
+}
+
+namespace Utilities
+{
+    /// Computation for the estimate (upper bound) on the number of non zero entries in a matrix.
+    class SparsityEstimator
+    {
+    public:
+        /// Construct a SparsityEstimator
+        /// \param mesh  The mesh
+        /// \param indexing The indexing for the basis functions
+        SparsityEstimator(const Base::MeshManipulatorBase& mesh, const GlobalIndexing& indexing);
+
+        /// Compute the sparsity estimate
+        /// \param nonZeroPerRowOwned [out] Per local DoF the number of non zero columns from
+        ///     locally owned basis functions.
+        /// \param nonZeroPerRowNonOwned [out] Per local DoF the number of non zero columns
+        ///     from non locally owned basis functions.
+        void computeSparsityEstimate(std::vector<int>& nonZeroPerRowOwned, std::vector<int>& nonZeroPerRowNonOwned) const;
+
+    private:
+        /// Workspace variables for the computation
+        struct Workspace;
+
+        /// Add the DoFs that have support on an Element to the workspace.
+        void addElementDoFs(const Base::Element* element, Workspace& workspace) const;
+
+
+        /// The mesh for the sparisity estimate
+        const Base::MeshManipulatorBase& mesh_;
+        /// The indexing for the basis functions
+        const GlobalIndexing& indexing_;
+    };
+}
+
+
+#endif //HPGEM_SPARSITYESTIMATOR_H

--- a/kernel/Utilities/SparsityEstimator.h
+++ b/kernel/Utilities/SparsityEstimator.h
@@ -41,7 +41,17 @@ namespace Utilities
         void addElementDoFs(const Base::Element* element, Workspace& workspace) const;
 
 
-        /// The mesh for the sparisity estimate
+        /// Write the DoF count for an Element, Face, etc. to the sparsity estimate vector
+        /// \tparam GEOM The Element, Face, etc. type
+        /// \param geom The Element, Face, etc. which supports the basis functions for which to write the DoF count.
+        /// \param workspace The workspace with DoF counts
+        /// \param nonZeroPerRowOwned see computeSparsityEstimate(std::vector<int>&, std::vector<int>&)
+        /// \param nonZeroPerRowNonOwned see computeSparsityEstimate(std::vector<int>&, std::vector<int>&)
+        template<typename GEOM>
+        void writeDoFCount(const GEOM* geom, const Workspace& workspace,
+                std::vector<int>& nonZeroPerRowOwned, std::vector<int>& nonZeroPerRowNonOwned) const;
+
+        /// The mesh for the sparsity estimate
         const Base::MeshManipulatorBase& mesh_;
         /// The indexing for the basis functions
         const GlobalIndexing& indexing_;

--- a/tests/self/PETSc/007SparsityEstimator_SelfTest.cpp
+++ b/tests/self/PETSc/007SparsityEstimator_SelfTest.cpp
@@ -1,0 +1,223 @@
+/*
+ This file forms part of hpGEM. This package has been developed over a number of years by various people at the University of Twente and a full list of contributors can be found at
+ http://hpgem.org/about-the-code/team
+
+ This code is distributed using BSD 3-Clause License. A copy of which can found below.
+
+
+ Copyright (c) 2020, University of Twente
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+ 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "CMakeDefinitions.h"
+
+#include "Base/MeshManipulator.h"
+#include "Base/CommandLineOptions.h"
+
+#include "Utilities/GlobalIndexing.h"
+#include "Utilities/SparsityEstimator.h"
+
+using Layout = Utilities::GlobalIndexing::Layout;
+
+void testWithDGBasis(std::size_t unknowns, std::string meshFile)
+{
+    Base::ConfigurationData config (unknowns);
+    Base::MeshManipulator<3> mesh (&config);
+
+    using namespace std::string_literals;
+    std::stringstream filename;
+    filename << Base::getCMAKE_hpGEM_SOURCE_DIR() + "/tests/files/"s << meshFile << ".hpgem";
+    mesh.readMesh(filename.str());
+
+    mesh.useDefaultDGBasisFunctions(0);
+    for (std::size_t unknown = 1; unknown < unknowns; ++unknown)
+    {
+        // Use more than zeroth order DG
+        mesh.useDefaultDGBasisFunctions(unknown, unknown);
+    }
+
+    for (Layout layout : {Layout::SEQUENTIAL, Layout::BLOCKED_PROCESSOR, Layout::BLOCKED_GLOBAL})
+    {
+        Utilities::GlobalIndexing indexing(&mesh, layout);
+        Utilities::SparsityEstimator estimator(mesh, indexing);
+
+        std::vector<int> owned, nonOwned;
+        estimator.computeSparsityEstimate(owned, nonOwned);
+        logger.assert_always(owned.size() == indexing.getNumberOfLocalBasisFunctions(), "Wrong size owned");
+        logger.assert_always(nonOwned.size() == indexing.getNumberOfLocalBasisFunctions(), "Wrong size owned");
+
+        for (const Base::Element *element : mesh.getElementsList())
+        {
+            std::size_t numberOfOwnDoFs = element->getTotalLocalNumberOfBasisFunctions();
+            std::size_t numberOfNonOwnDoFs = 0;
+            for (const Base::Face *face : element->getFacesList())
+            {
+                if (face->getFaceType() == Geometry::FaceType::SUBDOMAIN_BOUNDARY
+                    || face->getFaceType() == Geometry::FaceType::PERIODIC_SUBDOMAIN_BC)
+                {
+                    numberOfNonOwnDoFs += face->getPtrOtherElement(element)->getTotalLocalNumberOfBasisFunctions();
+                }
+                else if (face->isInternal())
+                {
+                    numberOfOwnDoFs += face->getPtrOtherElement(element)->getTotalLocalNumberOfBasisFunctions();
+                }
+            }
+
+            for (std::size_t unknown = 0; unknown < unknowns; ++unknown)
+            {
+                // Check for each of the basis functions
+                std::size_t dof = indexing.getProcessorLocalIndex(element, unknown);
+                for (std::size_t dofOff = 0; dofOff < element->getLocalNumberOfBasisFunctions(unknown); ++dofOff)
+                {
+                    logger.assert_always(owned[dof + dofOff] == numberOfOwnDoFs,
+                            "Expected % owned non zero entries but got %",
+                            numberOfOwnDoFs, owned[dof + dofOff]);
+                    logger.assert_always(nonOwned[dof + dofOff] == numberOfNonOwnDoFs,
+                            "Expected % non owned non zero entries but got %",
+                            numberOfNonOwnDoFs, nonOwned[dof + dofOff]);
+                }
+            }
+        }
+    }
+}
+
+template<typename GEOM, typename T>
+T& selectByOwner(const GEOM* geom, T& owned, T& nonOwned)
+{
+    if(geom->isOwnedByCurrentProcessor())
+        return owned;
+    else
+        return nonOwned;
+}
+
+
+void testConformingWith1DMesh()
+{
+    Base::ConfigurationData config (1);
+    Base::MeshManipulator<1> mesh (&config);
+
+    using namespace std::string_literals;
+    std::stringstream filename;
+    filename << Base::getCMAKE_hpGEM_SOURCE_DIR() + "/tests/files/"s << "1Drectangular2mesh"s << ".hpgem";
+    mesh.readMesh(filename.str());
+
+    mesh.useDefaultConformingBasisFunctions(2);
+
+    for (Layout layout : {Layout::SEQUENTIAL, Layout::BLOCKED_PROCESSOR, Layout::BLOCKED_GLOBAL})
+    {
+        Utilities::GlobalIndexing indexing(&mesh, layout);
+        Utilities::SparsityEstimator estimator(mesh, indexing);
+
+        std::vector<int> owned, nonOwned;
+        estimator.computeSparsityEstimate(owned, nonOwned);
+        logger.assert_always(owned.size() == indexing.getNumberOfLocalBasisFunctions(), "Wrong size owned");
+        logger.assert_always(nonOwned.size() == indexing.getNumberOfLocalBasisFunctions(), "Wrong size owned");
+
+        // Check for Element based DoF
+        for (const Base::Element* element : mesh.getElementsList())
+        {
+            // The following DoFs are contributing
+            // The DoFs from the element and its neighbours
+            // The DoFs from the faces to element
+            // The DoFs from the faces of the neighbouring elements
+            std::size_t numberOfOwnDoFs = element->getTotalLocalNumberOfBasisFunctions();
+            std::size_t numberOfNonOwnDoFs = 0;
+            for (const Base::Face * face : element->getFacesList())
+            {
+                selectByOwner(face, numberOfOwnDoFs, numberOfNonOwnDoFs) += face->getTotalLocalNumberOfBasisFunctions();
+                if (!face->isInternal())
+                    continue;
+                // The neighbouring element
+                const Base::Element* otherElement = face->getPtrOtherElement(element);
+                selectByOwner(otherElement, numberOfOwnDoFs, numberOfNonOwnDoFs)
+                    += element->getTotalLocalNumberOfBasisFunctions();
+                // Other face of the neighbour
+                const Base::Face* otherFace = otherElement->getFace(otherElement->getFace(0) == face ? 1 : 0);
+                selectByOwner(otherFace, numberOfOwnDoFs, numberOfNonOwnDoFs)
+                    += otherFace->getTotalLocalNumberOfBasisFunctions();
+            }
+            // Check
+            for (std::size_t unknown = 0; unknown < indexing.getNumberOfUnknowns(); ++unknown)
+            {
+                // Check for each of the basis functions
+                std::size_t dof = indexing.getProcessorLocalIndex(element, unknown);
+                for (std::size_t dofOff = 0; dofOff < element->getLocalNumberOfBasisFunctions(unknown); ++dofOff)
+                {
+                    logger.assert_always(owned[dof + dofOff] == numberOfOwnDoFs,
+                            "Expected % owned non zero entries but got %",
+                            numberOfOwnDoFs, owned[dof + dofOff]);
+                    logger.assert_always(nonOwned[dof + dofOff] == numberOfNonOwnDoFs,
+                            "Expected % non owned non zero entries but got %",
+                            numberOfNonOwnDoFs, nonOwned[dof + dofOff]);
+                }
+            }
+        }
+        // Check for Face based DoFs
+        for (const Base::Face* face : mesh.getFacesList())
+        {
+            // The contributions are from
+            // The DoFs on the face
+            // The DoFs from the element adjacent to the face it its faces
+            // The DoFs from the element adjecent to those and their faces.
+            std::vector<const Base::Element*> elements ({face->getPtrElementLeft()});
+            if (face->isInternal())
+                elements.emplace_back(face->getPtrElementRight());
+            std::size_t numberOfOwnDoFs = face->getTotalLocalNumberOfBasisFunctions();
+            std::size_t numberOfNonOwnDoFs = 0;
+            for (const Base::Element* element : elements)
+            {
+                selectByOwner(element, numberOfOwnDoFs, numberOfNonOwnDoFs)
+                    += element->getTotalLocalNumberOfBasisFunctions();
+                const Base::Face* otherFace = element->getFace(element->getFace(0) == face ? 1 : 0);
+                selectByOwner(otherFace, numberOfOwnDoFs, numberOfNonOwnDoFs)
+                    += otherFace->getTotalLocalNumberOfBasisFunctions();
+                // Next element
+                if (!otherFace->isInternal())
+                    continue;
+                const Base::Element* nextElement = otherFace->getPtrOtherElement(element);
+                selectByOwner(nextElement, numberOfOwnDoFs, numberOfNonOwnDoFs)
+                    += nextElement->getTotalLocalNumberOfBasisFunctions();
+                const Base::Face* nextFace = nextElement->getFace(nextElement->getFace(0) == otherFace ? 1 : 0);
+                selectByOwner(nextFace, numberOfOwnDoFs, numberOfNonOwnDoFs)
+                    += nextFace->getTotalLocalNumberOfBasisFunctions();
+            }
+            // Check
+            for (std::size_t unknown = 0; unknown < indexing.getNumberOfUnknowns(); ++unknown)
+            {
+                // Check for each of the basis functions
+                std::size_t dof = indexing.getProcessorLocalIndex(face, unknown);
+                for (std::size_t dofOff = 0; dofOff < face->getLocalNumberOfBasisFunctions(unknown); ++dofOff)
+                {
+                    logger.assert_always(owned[dof + dofOff] == numberOfOwnDoFs,
+                            "Expected % owned non zero entries but got %",
+                            numberOfOwnDoFs, owned[dof + dofOff]);
+                    logger.assert_always(nonOwned[dof + dofOff] == numberOfNonOwnDoFs,
+                            "Expected % non owned non zero entries but got %",
+                            numberOfNonOwnDoFs, nonOwned[dof + dofOff]);
+                }
+            }
+        }
+    }
+}
+
+int main(int argc, char** argv)
+{
+    using namespace std::string_literals;
+    Base::parse_options(argc, argv);
+
+    testWithDGBasis(1, "3Drectangular1mesh"s);
+    testWithDGBasis(3, "3Drectangular1mesh"s);
+    testWithDGBasis(1, "3Dtriangular1mesh"s);
+
+    testConformingWith1DMesh();
+}


### PR DESCRIPTION
This replaces the code to estimate the number of non zero entries for `GlobalMatrix` by a new class `SparsityEstimator` that should exactly compute the sparsity pattern. Unlike the previous code this is tested and documented.

In addition to the included unit test it is also tested by setting the `MAT_NEW_NONZERO_ALLOCATION_ERR` option on the PetscMatrix, which causes errors when new entries need to be allocated. With this option set both the test suite and DGMax have been run. 
