### PR TITLE
removed val_array

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,17 +59,6 @@ option(hpGEM_USE_COMPLEX_PETSC "Include PETSc with complex numbers" OFF)
 option(hpGEM_USE_SLEPC "Include SLEPC this is needed for some applications" OFF)
 option(hpGEM_USE_SUNDIALS "Include SUNDIALS containing robust time integrators and nonlinear solvers" OFF)
 
-# Old option (partially broken) to use valarray in the linear algebra classes
-option(hpGEM_USE_STL_VECTOR_FOR_LA "Will swap the internal storage of the linear algebra from being based on valarray to STL vector" ON)
-mark_as_advanced(hpGEM_USE_STL_VECTOR_FOR_LA)
-if(hpGEM_USE_STL_VECTOR_FOR_LA)
-	add_definitions(-DLA_STL_VECTOR)
-endif(hpGEM_USE_STL_VECTOR_FOR_LA)
-if (NOT hpGEM_USE_STL_VECTOR_FOR_LA)
-	message (FATAL_ERROR
-		"Val array is no longer support; please select use hpGEM_USE_STK_VECTOR_FOR_LA")
-endif()
-
 
 ################################################################################
 ####### LOGGER CONFIGURATION

--- a/kernel/LinearAlgebra/MiddleSizeMatrix.cpp
+++ b/kernel/LinearAlgebra/MiddleSizeMatrix.cpp
@@ -101,11 +101,7 @@ namespace LinearAlgebra
     /// matrix called A with entries equal to 2.
     MiddleSizeMatrix::MiddleSizeMatrix(const std::size_t n, const std::size_t m, const type& c)
             :
-#ifdef LA_STL_VECTOR
                     data_(n * m, c),
-#else
-                    data_(c, n*m),
-#endif
                     numberOfRows_(n), numberOfColumns_(m)
     {
         logger.assert_debug(n <= std::numeric_limits<int>::max() && m <= std::numeric_limits<int>::max(),
@@ -203,12 +199,8 @@ namespace LinearAlgebra
     /// \return Matrix
     MiddleSizeMatrix& MiddleSizeMatrix::operator*=(const type &scalar)
     {
-#ifdef LA_STL_VECTOR
         for (type& d : data_)
             d *= scalar;
-#else
-        data_ *= scalar;
-#endif
         return *this;
     }
 
@@ -216,12 +208,8 @@ namespace LinearAlgebra
     /// \return Matrix
     MiddleSizeMatrix& MiddleSizeMatrix::operator/=(const type& scalar)
     {
-#ifdef LA_STL_VECTOR
         for (type& d : data_)
             d /= scalar;
-#else
-        data_/=scalar;
-#endif
         return *this;
     }
 
@@ -408,11 +396,7 @@ namespace LinearAlgebra
             numberOfColumns_ = 1;
             data_.resize(1);
         }
-#ifdef LA_STL_VECTOR
         data_[0] = c;
-#else
-        data_=c;
-#endif
         return *this;
     }
     
@@ -517,11 +501,7 @@ namespace LinearAlgebra
         logger.assert_debug(numberOfRows_ + other.numberOfRows_ <= std::numeric_limits<int>::max(),
                             "Dense linear algebra is not supported on this system for matrices that are this large");
         
-#ifdef LA_STL_VECTOR
         std::vector<type> data_new(numberOfColumns_ * (numberOfRows_ + other.numberOfRows_));
-#else
-        std::valarray<type> data_new(numberOfColumns_ * (numberOfRows_ + other.numberOfRows_));
-#endif
         
         for (std::size_t col = 0; col < numberOfColumns_; ++col)
         {

--- a/kernel/LinearAlgebra/MiddleSizeMatrix.h
+++ b/kernel/LinearAlgebra/MiddleSizeMatrix.h
@@ -24,11 +24,7 @@
 
 // System includes
 #include <iostream>
-#ifdef LA_STL_VECTOR
 #include <vector>
-#else
-#include <valarray>
-#endif
 
 #include "MiddleSizeVector.h"
 #include <complex>
@@ -48,7 +44,6 @@ namespace LinearAlgebra
     ///     0   2 
     ///     1   3
     /// Examples for the implementation are given in the unit test (../tests/unit/LinearAlgebra/MatrixUnitTest).
-    /// \bug valarray does not compile, since data() is not defined on it
     /// implement fall-back routines for matrices that are too large. Note that in this situation dense data storage may not be the best option
     class MiddleSizeMatrix
     {
@@ -242,12 +237,8 @@ namespace LinearAlgebra
 
     private:
         /// The actually data of the matrix class
-#ifdef LA_STL_VECTOR
         std::vector<type> data_;
-#else
-#error "valarray is broken, please turn on hpGEM_USE_STL_VECTOR_FOR_LA"
-        std::valarray<type> data_;
-#endif
+
         
         /// Stores the number of rows of the matrix
         std::size_t numberOfRows_;

--- a/kernel/LinearAlgebra/MiddleSizeVector.cpp
+++ b/kernel/LinearAlgebra/MiddleSizeVector.cpp
@@ -65,16 +65,12 @@ namespace LinearAlgebra
     {
     }
     
-#ifdef LA_STL_VECTOR
+
     MiddleSizeVector::MiddleSizeVector(const type array[], std::size_t size)
             : data_(array, array + size)
     {
     }
-#else
-    MiddleSizeVector::MiddleSizeVector(const type array[], std::size_t size)
-    : data_(array, size)
-    {}
-#endif
+
     
     void MiddleSizeVector::resize(std::size_t size)
     {
@@ -101,12 +97,8 @@ namespace LinearAlgebra
     {
         MiddleSizeVector result(*this);
         logger.assert_debug(data_.size() == right.data_.size(), "Vectors don't have the same size");
-#ifdef LA_STL_VECTOR
         for (std::size_t i = 0; i < data_.size(); i++)
             result.data_[i] += right.data_[i];
-#else
-        result.data_+=right.data_;
-#endif
         
         return result;
     }
@@ -115,24 +107,16 @@ namespace LinearAlgebra
     {
         MiddleSizeVector result(*this);
         logger.assert_debug(data_.size() == right.data_.size(), "Vectors don't have the same size");
-#ifdef LA_STL_VECTOR
         for (std::size_t i = 0; i < data_.size(); i++)
             result.data_[i] -= right.data_[i];
-#else
-        result.data_-=right.data_;
-#endif
         return result;
     }
     
     MiddleSizeVector MiddleSizeVector::operator*(const type& right) const
     {
         MiddleSizeVector result(*this);
-#ifdef LA_STL_VECTOR
         for (type& d : result.data_)
             d *= right;
-#else
-        result.data_*=right;
-#endif
         
         return result;
     }
@@ -141,25 +125,17 @@ namespace LinearAlgebra
     {
         ///\todo replace with BLAS
         logger.assert_debug(data_.size() == right.data_.size(), "Vectors don't have equal length.");
-#ifdef LA_STL_VECTOR
         type sum = 0;
         for (std::size_t i = 0; i < data_.size(); i++)
             sum += data_[i] * right.data_[i];
         return sum;
-#else
-        return (data_*right.data_).sum();
-#endif
     }
     
     MiddleSizeVector& MiddleSizeVector::operator/=(const type& right)
     {
-#ifdef LA_STL_VECTOR
+
         for (type& d : data_)
             d /= right;
-#else
-        data_/=right;
-#endif
-        
         return *this;
     }
     
@@ -222,36 +198,23 @@ namespace LinearAlgebra
     MiddleSizeVector& MiddleSizeVector::operator+=(const MiddleSizeVector& right)
     {
         logger.assert_debug(data_.size() == right.data_.size(), "Vectors don't have the same size");
-#ifdef LA_STL_VECTOR
         for (std::size_t i = 0; i < data_.size(); i++)
             data_[i] += right.data_[i];
-#else
-        data_+=right.data_;
-#endif
         return *this;
     }
     
     MiddleSizeVector& MiddleSizeVector::operator-=(const MiddleSizeVector& right)
     {
         logger.assert_debug(data_.size() == right.data_.size(), "Vectors don't have the same size");
-#ifdef LA_STL_VECTOR
         for (std::size_t i = 0; i < data_.size(); i++)
             data_[i] -= right.data_[i];
-        
-#else
-        data_-=right.data_;
-#endif
         return *this;
     }
     
     MiddleSizeVector& MiddleSizeVector::operator*=(const type& right)
     {
-#ifdef LA_STL_VECTOR
         for (type& d : data_)
             d *= right;
-#else
-        data_*=right;
-#endif
         return *this;
     }
     

--- a/kernel/LinearAlgebra/MiddleSizeVector.h
+++ b/kernel/LinearAlgebra/MiddleSizeVector.h
@@ -22,14 +22,10 @@
 #ifndef MIDDLESIZEVECTOR_H_
 #define MIDDLESIZEVECTOR_H_
 
-//This is derived from valarray or vector so import that information
+
 #include "Logger.h"
-#ifdef LA_STL_VECTOR
 #include <vector>
 #include <cmath>
-#else
-#include <valarray>
-#endif
 #include <iostream>
 #include <complex>
 
@@ -94,7 +90,6 @@ namespace LinearAlgebra
 
         /// This function is dangerous to use, since it compares doubles without 
         /// a tolerance interval to see if they are equal.
-        /// Needs fixing if someone wants to use valarray.
         bool operator==(const MiddleSizeVector& right) const;
 
         /// This function is dangerous to use, since it compares doubles without
@@ -143,11 +138,9 @@ namespace LinearAlgebra
         }
 
     private:
-#ifdef LA_STL_VECTOR
+
         std::vector<type> data_;
-#else
-        std::valarray<type> data_;
-#endif
+
         
     };
 


### PR DESCRIPTION
According to the doc it is broken and it has not been used and there is no benefit in keeping both, especially with modern compilers. 

If we want a better linear algebra package, we can still apply Eigen or some other linear algebra package. 