### PR TITLE
Refinement fixes

### DIFF
--- a/kernel/Base/LevelTree.h
+++ b/kernel/Base/LevelTree.h
@@ -68,6 +68,10 @@ class LevelTree {
     //! clean up the entries (does not do memory management on V)
     ~LevelTree();
 
+    // Disallow copying, as we own pointers to TreeEntry-s.
+    LevelTree(const LevelTree<V>& other) = delete;
+    LevelTree<V>& operator=(const LevelTree<V>&) = delete;
+
     //! false if there are entries in the tree
     bool empty() const;
 

--- a/kernel/Base/MeshManipulator_Impl.h
+++ b/kernel/Base/MeshManipulator_Impl.h
@@ -1441,7 +1441,8 @@ void MeshManipulator<DIM>::refine(
                     subElementNodeIndices.push_back(globalPointIndices[j]);
                 }
                 auto newElement = ElementFactory::instance().makeElement(
-                    subElementNodeIndices, theMesh_.getNodeCoordinates());
+                    subElementNodeIndices, theMesh_.getNodeCoordinates(),
+                    element->getOwner(), element->isOwnedByCurrentProcessor());
                 subElements.push_back(newElement);
                 for (std::size_t j = 0;
                      j < refinementMapping->getSubElementReferenceGeometry(i)


### PR DESCRIPTION
Some simple fixes to make the mesh refinement function compile again. This was broken by the introduction of explicit ownership in b4d28c9 (and some later commits), but the compiler did not detect it.

