### PR TITLE
Rename all job ids for the workflows

### DIFF
--- a/.github/workflows/Basic.yml
+++ b/.github/workflows/Basic.yml
@@ -7,7 +7,8 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
+  # Workflow name included as the job-id is sometimes listed without workflow name.
+  run-tests-basic:
 
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/PETSC_complex.yml
+++ b/.github/workflows/PETSC_complex.yml
@@ -7,7 +7,8 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
+  # Workflow name included as the job-id is sometimes listed without workflow name.
+  run-tests-complex-petsc:
 
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/QHull.yml
+++ b/.github/workflows/QHull.yml
@@ -7,7 +7,8 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
+  # Workflow name included as the job-id is sometimes listed without workflow name.
+  run-tests-qhull:
 
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/checkformat.yml
+++ b/.github/workflows/checkformat.yml
@@ -6,7 +6,7 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
+  check-formatting:
 
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -6,7 +6,7 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
+  code-coverage:
 
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -6,7 +6,7 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
+  run-tests-complex-petsc:
 
     runs-on: macos-latest
     strategy:


### PR DESCRIPTION
As the job names for the github workflows were identical, there was no
way to distinguish them when the workflow name was not included. This is
for example a problem when protecting branches, where only the jobids
are listed.