### PR TITLE
Higher order 2dnedelec

### DIFF
--- a/kernel/Utilities/BasisFunctions1DH1ConformingLine.cpp
+++ b/kernel/Utilities/BasisFunctions1DH1ConformingLine.cpp
@@ -72,17 +72,27 @@ double BasisFunction1DInteriorLine::evalDeriv0(
                LobattoPolynomialDerivative(polynomialOrder_, p[0]) / 4.;
 }
 
-Base::BasisFunctionSet* createDGBasisFunctionSet1DH1Line(
+std::vector<Base::BaseBasisFunction*> createDGBasisFunctions1DH1Line(
     std::size_t polynomialOrder) {
-    Base::BasisFunctionSet* result(new Base::BasisFunctionSet(polynomialOrder));
+    std::vector<Base::BaseBasisFunction*> result;
     if (polynomialOrder > 0) {
-        result->addBasisFunction(new BasisFunction1DVertexLine(0));
-        result->addBasisFunction(new BasisFunction1DVertexLine(1));
+        result.emplace_back(new BasisFunction1DVertexLine(0));
+        result.emplace_back(new BasisFunction1DVertexLine(1));
         for (std::size_t i = 0; i + 2 <= polynomialOrder; ++i) {
-            result->addBasisFunction(new BasisFunction1DInteriorLine(i));
+            result.emplace_back(new BasisFunction1DInteriorLine(i));
         }
     } else {
-        addPiecewiseConstantBasisFunction1D(*result);
+        result.emplace_back(createPiecewiseConstant1D());
+    }
+    return result;
+}
+
+Base::BasisFunctionSet* createDGBasisFunctionSet1DH1Line(
+    std::size_t polynomialOrder) {
+
+    Base::BasisFunctionSet* result(new Base::BasisFunctionSet(polynomialOrder));
+    for (auto* bf : createDGBasisFunctions1DH1Line(polynomialOrder)) {
+        result->addBasisFunction(bf);
     }
     return result;
 }

--- a/kernel/Utilities/BasisFunctions1DH1ConformingLine.h
+++ b/kernel/Utilities/BasisFunctions1DH1ConformingLine.h
@@ -87,6 +87,9 @@ class BasisFunction1DInteriorLine : public Base::BaseBasisFunction {
 Base::BasisFunctionSet* createDGBasisFunctionSet1DH1Line(
     std::size_t polynomialOrder);
 
+std::vector<Base::BaseBasisFunction*> createDGBasisFunctions1DH1Line(
+    std::size_t polynomialOrder);
+
 Base::BasisFunctionSet* createInteriorBasisFunctionSet1DH1Line(
     std::size_t polynomialOrder);
 

--- a/kernel/Utilities/BasisFunctions2DH1ConformingTriangle.cpp
+++ b/kernel/Utilities/BasisFunctions2DH1ConformingTriangle.cpp
@@ -173,29 +173,38 @@ double BasisFunction2DInteriorTriangle::evalDeriv1(
                     LobattoPolynomialDerivative(polynomialOrder1_, x1));
 }
 
-Base::BasisFunctionSet* createDGBasisFunctionSet2DH1Triangle(
+std::vector<Base::BaseBasisFunction*> createDGBasisFunctions2DH1Triangle(
     std::size_t order) {
-    Base::BasisFunctionSet* result(new Base::BasisFunctionSet(order));
+    std::vector<Base::BaseBasisFunction*> result;
     if (order > 0) {
         for (std::size_t i = 0; i < 3; ++i) {
-            result->addBasisFunction(new BasisFunction2DVertexTriangle(i));
+            result.emplace_back(new BasisFunction2DVertexTriangle(i));
         }
         for (std::size_t k = 0; k + 2 <= order; ++k) {
             for (std::size_t i = 0; i < 3; ++i) {
                 for (std::size_t j = 0; j < i; ++j) {
-                    result->addBasisFunction(
+                    result.emplace_back(
                         new BasisFunction2DFaceTriangle(i, j, k));
                 }
             }
             if (k + 3 <= order) {
                 for (std::size_t j = 0; j <= k; ++j) {
-                    result->addBasisFunction(
+                    result.emplace_back(
                         new BasisFunction2DInteriorTriangle(k - j, j));
                 }
             }
         }
     } else {
-        addPiecewiseConstantBasisFunction2D(*result);
+        result.emplace_back(createPiecewiseConstant2D());
+    }
+    return result;
+}
+
+Base::BasisFunctionSet* createDGBasisFunctionSet2DH1Triangle(
+    std::size_t order) {
+    Base::BasisFunctionSet* result(new Base::BasisFunctionSet(order));
+    for (auto* bf : createDGBasisFunctions2DH1Triangle(order)) {
+        result->addBasisFunction(bf);
     }
     return result;
 }

--- a/kernel/Utilities/BasisFunctions2DH1ConformingTriangle.h
+++ b/kernel/Utilities/BasisFunctions2DH1ConformingTriangle.h
@@ -108,6 +108,8 @@ class BasisFunction2DInteriorTriangle : public Base::BaseBasisFunction {
     std::size_t polynomialOrder0_, polynomialOrder1_;
 };
 
+std::vector<Base::BaseBasisFunction*> createDGBasisFunctions2DH1Triangle(
+    std::size_t order);
 Base::BasisFunctionSet* createDGBasisFunctionSet2DH1Triangle(std::size_t order);
 
 Base::BasisFunctionSet* createInteriorBasisFunctionSet2DH1Triangle(

--- a/kernel/Utilities/BasisFunctions2DNedelec.cpp
+++ b/kernel/Utilities/BasisFunctions2DNedelec.cpp
@@ -42,6 +42,9 @@
 #include "Geometry/ReferenceTriangle.h"
 #include "Geometry/PointReference.h"
 
+#include "BasisFunctions1DH1ConformingLine.h"
+#include "BasisFunctions2DH1ConformingTriangle.h"
+
 namespace hpgem {
 
 namespace Utilities {
@@ -61,53 +64,178 @@ LinearAlgebra::SmallVector<2> baricentricDeriv(std::size_t node) {
 }
 }  // namespace
 
-BasisCurlEdgeNedelec2D::BasisCurlEdgeNedelec2D(std::size_t degree1,
-                                               std::size_t degree2,
-                                               std::size_t localFirstVertex,
-                                               std::size_t localSecondVertex)
-    : deg1(degree1), deg2(degree2), i(localFirstVertex), j(localSecondVertex) {
-    logger.assert_debug(
-        deg1 < 1 && deg2 < 1,
-        "2D Nedelec basis functions only implemented for p = 1");
-    logger.assert_debug(i < 3 && j < 3, "A triangle only has 3 nodes");
+BasisCurlEdgeNedelec2D::BasisCurlEdgeNedelec2D(
+    std::size_t side, std::shared_ptr<const Base::BaseBasisFunction> modulator)
+    : side_(side), modulator_(std::move(modulator)) {
+    logger.assert_debug(side <= 2, "Triangle has only three sides");
 }
 
 void BasisCurlEdgeNedelec2D::eval(const Geometry::PointReference<2>& p,
                                   LinearAlgebra::SmallVector<2>& ret) const {
-    LinearAlgebra::SmallVector<2> dummy;
 
-    ret = baricentricDeriv(i);
-    dummy = baricentricDeriv(j);
-
-    double valI(baricentric_2D(i, p)), valJ(baricentric_2D(j, p));
-
-    ret *= valJ;
-    dummy *= valI;
-    ret -= dummy;
+    evalSideFunction(p, ret);
+    Geometry::PointReference<1> coord;
+    coord[0] = evalModulatorCoord(p);
+    ret *= modulator_->eval(coord);
 }
 
 LinearAlgebra::SmallVector<2> BasisCurlEdgeNedelec2D::evalCurl(
     const Geometry::PointReference<2>& p) const {
-    LinearAlgebra::SmallVector<2> dummy, dummy2, ret;
 
-    dummy = baricentricDeriv(i);
-    dummy2 = baricentricDeriv(j);
+    double result;
 
-    double valI(baricentric_2D(i, p)), valJ(baricentric_2D(j, p));
+    Geometry::PointReference<1> modulatorCoord;
+    modulatorCoord[0] = evalModulatorCoord(p);
+    double modulatorVal = modulator_->eval(modulatorCoord);
+    LinearAlgebra::SmallVector<2> sideVal;
+    evalSideFunction(p, sideVal);
 
-    ret[0] = -2 * dummy2[1] * dummy[0] + 2 * dummy[1] * dummy2[0];
-    ret[1] = 0.0;
-    return ret;
+    // Compute rotation Fy/dx - Fx/dy from the side function
+    result = -2.0;
+    // By chain rule, multiply by modulator (q) value
+    result *= modulatorVal;
+    // Now second contribution, applying the derivatives to the modulator.
+    // Note that the modulator q(t) depends on only one coordinate, where
+    // t depends on side_.
+    if (side_ == 0) {
+        // t=x, so add dq/dt Fy
+        result += modulator_->evalDeriv0(modulatorCoord) * sideVal[1];
+    } else if (side_ == 1) {
+        // t=y, so add -dq/dt Fx
+        result -= modulator_->evalDeriv0(modulatorCoord) * sideVal[0];
+    } else {
+        // t = 1-y, so add +dq/dt Fx
+        result += modulator_->evalDeriv0(modulatorCoord) * sideVal[0];
+    }
+    return LinearAlgebra::SmallVector<2>({result, 0});
 }
 
+void BasisCurlEdgeNedelec2D::evalSideFunction(
+    const Geometry::PointReference<2>& p,
+    LinearAlgebra::SmallVector<2>& ret) const {
+
+    if (side_ == 0) {
+        ret[0] = p[1] - 1.0;
+        ret[1] = -p[0];
+    } else if (side_ == 1) {
+        ret[0] = p[1];
+        ret[1] = -p[0];
+    } else {
+        ret[0] = p[1];
+        ret[1] = 1.0 - p[0];
+    }
+}
+
+double BasisCurlEdgeNedelec2D::evalModulatorCoord(
+    const Geometry::PointReference<2>& p) const {
+    if (side_ == 0) {
+        return p[0];
+    } else if (side_ == 1) {
+        return p[1];
+    } else {
+        return 1 - p[1];
+    }
+}
+
+BasisFunctionCurlInteriorNedelec2D::BasisFunctionCurlInteriorNedelec2D(
+    std::size_t type, std::shared_ptr<const Base::BaseBasisFunction> modulator)
+    : type_(type), modulator_(std::move(modulator)) {
+    logger.assert_always(type == 0 || type == 1,
+                         "Only two interior types supported");
+}
+
+void BasisFunctionCurlInteriorNedelec2D::eval(
+    const Geometry::PointReference<2>& p,
+    LinearAlgebra::SmallVector<2>& ret) const {
+
+    // Type 0: x (y; 1-x) q(x,y), Type 1: y(1-y;x) q(x,y)
+    // where q is the modulating function
+
+    evalTypePart(p, ret);
+    double pval = modulator_->eval(p);
+    ret *= pval;
+}
+
+LinearAlgebra::SmallVector<2> BasisFunctionCurlInteriorNedelec2D::evalCurl(
+    const Geometry::PointReference<2>& p) const {
+
+    // Curl = rotation, thus F_y/dx - F_x/dy evaluated via the chain rule
+    double result;
+
+    LinearAlgebra::SmallVector<2> typeValue;
+    double typeFydx, typeFxdy;
+    double modulatorValue;
+    LinearAlgebra::SmallVector<2> modulatorGrad;
+
+    evalTypePart(p, typeValue);
+    if (type_ == 0) {
+        typeFydx = 1 - 2.0 * p[0];
+        typeFxdy = p[0];
+    } else {
+        typeFydx = p[1];
+        typeFxdy = 1 - 2.0 * p[1];
+    }
+    modulatorValue = modulator_->eval(p);
+    modulatorGrad = modulator_->evalDeriv(p);
+
+    // Chain rule part 1, F_y/dx
+    result = typeFydx * modulatorValue + typeValue[1] * modulatorGrad[0];
+    // Chain rule part 2, -F_x/dy
+    result -= typeFxdy * modulatorValue + typeValue[0] * modulatorGrad[1];
+
+    return LinearAlgebra::SmallVector<2>({result, 0.0});
+}
+
+void BasisFunctionCurlInteriorNedelec2D::evalTypePart(
+    const Geometry::PointReference<2>& p,
+    LinearAlgebra::SmallVector<2>& ret) const {
+    if (type_ == 0) {
+        ret[0] = p[1];
+        ret[1] = 1.0 - p[0];
+        ret *= p[0];
+    } else {
+        ret[0] = 1.0 - p[1];
+        ret[1] = p[0];
+        ret *= p[1];
+    }
+}
+
+std::vector<Base::BaseBasisFunction*> createDGBasisFunctions2DNedelec(
+    std::size_t order) {
+    //    logger.assert_debug(
+    //        order < 2, "2D Nedelec basis functions only implemented for p =
+    //        1");
+
+    std::vector<Base::BaseBasisFunction*> result;
+
+    std::vector<Base::BaseBasisFunction*> lineFunctions =
+        createDGBasisFunctions1DH1Line(order - 1);
+    for (auto& i : lineFunctions) {
+        auto lineFunction = std::shared_ptr<Base::BaseBasisFunction>(i);
+        result.emplace_back(new BasisCurlEdgeNedelec2D(0, lineFunction));
+        result.emplace_back(new BasisCurlEdgeNedelec2D(1, lineFunction));
+        result.emplace_back(new BasisCurlEdgeNedelec2D(2, lineFunction));
+    }
+
+    if (order > 1) {
+        std::vector<Base::BaseBasisFunction*> triangleFunctions =
+            createDGBasisFunctions2DH1Triangle(order - 2);
+        for (auto& i : triangleFunctions) {
+            auto triangleFunction = std::shared_ptr<Base::BaseBasisFunction>(i);
+            result.emplace_back(
+                new BasisFunctionCurlInteriorNedelec2D(0, triangleFunction));
+            result.emplace_back(
+                new BasisFunctionCurlInteriorNedelec2D(1, triangleFunction));
+        }
+    }
+    return result;
+}
 Base::BasisFunctionSet* createDGBasisFunctionSet2DNedelec(std::size_t order) {
-    logger.assert_debug(
-        order < 2, "2D Nedelec basis functions only implemented for p = 1");
-    Base::BasisFunctionSet* bFset = new Base::BasisFunctionSet(order);
-    bFset->addBasisFunction(new BasisCurlEdgeNedelec2D(0, 0, 0, 1));
-    bFset->addBasisFunction(new BasisCurlEdgeNedelec2D(0, 0, 0, 2));
-    bFset->addBasisFunction(new BasisCurlEdgeNedelec2D(0, 0, 1, 2));
-    return bFset;
+    Base::BasisFunctionSet* set = new Base::BasisFunctionSet(order);
+    for (auto* bf : createDGBasisFunctions2DNedelec(order)) {
+        set->addBasisFunction(bf);
+    }
+    return set;
 }
 }  // namespace Utilities
 

--- a/kernel/Utilities/BasisFunctions2DNedelec.cpp
+++ b/kernel/Utilities/BasisFunctions2DNedelec.cpp
@@ -62,7 +62,7 @@ namespace Utilities {
 /// The function q_p(t) is shared between the sides and 'modulates' the vector
 /// field by a polynomial of order p-1. The coordinate t is linear on the side
 /// to which the basis function is associated.
-class BasisCurlEdgeNedelec2D : public Base::BaseBasisFunction {
+class BasisCurlEdgeNedelec2D final: public Base::BaseBasisFunction {
    public:
     BasisCurlEdgeNedelec2D(
         std::size_t side,
@@ -121,7 +121,6 @@ class BasisCurlEdgeNedelec2D : public Base::BaseBasisFunction {
 LinearAlgebra::SmallVector<2> BasisCurlEdgeNedelec2D::evalCurl(
     const Geometry::PointReference<2>& p) const {
 
-    double result;
 
     Geometry::PointReference<1> modulatorCoord;
     modulatorCoord[0] = evalModulatorCoord(p);
@@ -130,7 +129,7 @@ LinearAlgebra::SmallVector<2> BasisCurlEdgeNedelec2D::evalCurl(
     evalSideFunction(p, sideVal);
 
     // Compute rotation Fy/dx - Fx/dy from the side function
-    result = -2.0;
+    double result = -2.0;
     // By chain rule, multiply by modulator (q) value
     result *= modulatorVal;
     // Now second contribution, applying the derivatives to the modulator.

--- a/kernel/Utilities/BasisFunctions2DNedelec.cpp
+++ b/kernel/Utilities/BasisFunctions2DNedelec.cpp
@@ -66,8 +66,8 @@ class BasisCurlEdgeNedelec2D final: public Base::BaseBasisFunction {
    public:
     BasisCurlEdgeNedelec2D(
         std::size_t side,
-        std::shared_ptr<const Base::BaseBasisFunction> modulator)
-        : side_(side), modulator_(std::move(modulator)) {
+        std::shared_ptr<const Base::BaseBasisFunction>& modulator)
+        : side_(side), modulator_(modulator) {
 
         logger.assert_debug(side <= 2, "Triangle has only three sides");
     }
@@ -160,8 +160,8 @@ class BasisFunctionCurlInteriorNedelec2D : public Base::BaseBasisFunction {
    public:
     BasisFunctionCurlInteriorNedelec2D(
         std::size_t type,
-        std::shared_ptr<const Base::BaseBasisFunction> modulator)
-        : type_(type), modulator_(std::move(modulator)) {
+        std::shared_ptr<const Base::BaseBasisFunction>& modulator)
+        : type_(type), modulator_(modulator) {
         logger.assert_always(type == 0 || type == 1,
                              "Only two interior types supported");
     }
@@ -234,7 +234,7 @@ std::vector<Base::BaseBasisFunction*> createDGBasisFunctions2DNedelec(
     std::vector<Base::BaseBasisFunction*> lineFunctions =
         createDGBasisFunctions1DH1Line(order - 1);
     for (auto& i : lineFunctions) {
-        auto lineFunction = std::shared_ptr<Base::BaseBasisFunction>(i);
+        auto lineFunction = std::shared_ptr<const Base::BaseBasisFunction>(i);
         result.emplace_back(new BasisCurlEdgeNedelec2D(0, lineFunction));
         result.emplace_back(new BasisCurlEdgeNedelec2D(1, lineFunction));
         result.emplace_back(new BasisCurlEdgeNedelec2D(2, lineFunction));
@@ -244,7 +244,8 @@ std::vector<Base::BaseBasisFunction*> createDGBasisFunctions2DNedelec(
         std::vector<Base::BaseBasisFunction*> triangleFunctions =
             createDGBasisFunctions2DH1Triangle(order - 2);
         for (auto& i : triangleFunctions) {
-            auto triangleFunction = std::shared_ptr<Base::BaseBasisFunction>(i);
+            auto triangleFunction =
+                std::shared_ptr<const Base::BaseBasisFunction>(i);
             result.emplace_back(
                 new BasisFunctionCurlInteriorNedelec2D(0, triangleFunction));
             result.emplace_back(

--- a/kernel/Utilities/BasisFunctions2DNedelec.cpp
+++ b/kernel/Utilities/BasisFunctions2DNedelec.cpp
@@ -62,7 +62,7 @@ namespace Utilities {
 /// The function q_p(t) is shared between the sides and 'modulates' the vector
 /// field by a polynomial of order p-1. The coordinate t is linear on the side
 /// to which the basis function is associated.
-class BasisCurlEdgeNedelec2D final: public Base::BaseBasisFunction {
+class BasisCurlEdgeNedelec2D final : public Base::BaseBasisFunction {
    public:
     BasisCurlEdgeNedelec2D(
         std::size_t side,
@@ -120,7 +120,6 @@ class BasisCurlEdgeNedelec2D final: public Base::BaseBasisFunction {
 
 LinearAlgebra::SmallVector<2> BasisCurlEdgeNedelec2D::evalCurl(
     const Geometry::PointReference<2>& p) const {
-
 
     Geometry::PointReference<1> modulatorCoord;
     modulatorCoord[0] = evalModulatorCoord(p);

--- a/kernel/Utilities/BasisFunctions2DNedelec.h
+++ b/kernel/Utilities/BasisFunctions2DNedelec.h
@@ -39,72 +39,49 @@
 #ifndef HPGEM_KERNEL_BASISFUNCTIONS2DNEDELEC_H
 #define HPGEM_KERNEL_BASISFUNCTIONS2DNEDELEC_H
 
-#include "Base/BaseBasisFunction.h"
 #include <vector>
 #include <memory>
 
 namespace hpgem {
 
 namespace Base {
+class BaseBasisFunction;
 class BasisFunctionSet;
-}
-
-namespace Geometry {
-template <std::size_t DIM>
-class PointReference;
 }
 
 namespace Utilities {
 
-//! Curl conforming Nedelec edge functions.
-class BasisCurlEdgeNedelec2D : public Base::BaseBasisFunction {
-   public:
-    BasisCurlEdgeNedelec2D(
-        std::size_t side,
-        std::shared_ptr<const Base::BaseBasisFunction> modulator);
+/**
+ * Implementation of Nedelec functions based on the basis for Raviart-Thomas
+ * (RT) basis functions from [1]. We use the relation between H(div) and H(curl)
+ * vector fields in 2D. If F = (Fx, Fy) is a vector field in H(div) then
+ * rotating the vectors by 90 degrees (Fy, -Fx) one gets a vector field in
+ * H(curl). Similarly, rotating the fields of the RT basis functions, one gets a
+ * basis for the Nedelec space.
+ *
+ * As noted in [1] we can split the basis functions in two categories, edge and
+ * internal. With the slight difference that we use order = p = k+1 (paper) we
+ * have:
+ * - 3*p edge basis functions, one per edge
+ * - (p-1)*p internal basis functions
+ * For a total of p*(p+2) basis functions.
+ *
+ * [1] Computational bases for RT_k and BDM_k on triangles
+ * VJ Ervin, Computers & Mathematics with Applications 64 (8) 2764--2774
+ */
 
-    void eval(const Geometry::PointReference<2>& p,
-              LinearAlgebra::SmallVector<2>& ret) const override;
-
-    LinearAlgebra::SmallVector<2> evalCurl(
-        const Geometry::PointReference<2>& p) const override;
-
-   private:
-    // Eval the side dependent function
-    void evalSideFunction(const Geometry::PointReference<2>& p,
-                          LinearAlgebra::SmallVector<2>& ret) const;
-
-    double evalModulatorCoord(const Geometry::PointReference<2>& p) const;
-    // Side of the triangle which has non-zero tangential trace. The tangential
-    // trace is pointed counter clockwise along the edge of the triangle.
-    // Side 1 = (y-1,-x), side 2 = (y,-x), side 3 = (y,1-x)
-    std::size_t side_;
-    // 1D Modulation function for the basis functions.
-    std::shared_ptr<const Base::BaseBasisFunction> modulator_;
-};
-
-class BasisFunctionCurlInteriorNedelec2D : public Base::BaseBasisFunction {
-
-   public:
-    BasisFunctionCurlInteriorNedelec2D(
-        std::size_t type,
-        std::shared_ptr<const Base::BaseBasisFunction> modulator);
-    void eval(const Geometry::PointReference<2>& p,
-              LinearAlgebra::SmallVector<2>& ret) const override;
-
-    LinearAlgebra::SmallVector<2> evalCurl(
-        const Geometry::PointReference<2>& p) const override;
-
-   private:
-    void evalTypePart(const Geometry::PointReference<2>& p,
-                      LinearAlgebra::SmallVector<2>& ret) const;
-
-    // Type one or two
-    std::size_t type_;
-    std::shared_ptr<const Base::BaseBasisFunction> modulator_;
-};
-
+/**
+ * Create BasisFunctionSet for DG (elementwise) 2D Nedelec functions.
+ * @param order The order of the basis functions (highest polynomial degree)
+ * @return The set of basis functions, user owns the pointer.
+ */
 Base::BasisFunctionSet* createDGBasisFunctionSet2DNedelec(std::size_t order);
+
+/**
+ * Create BasisFunctionSet for DG (elementwise) 2D Nedelec functions.
+ * @param order The order of the basis functions (highest polynomial degree)
+ * @return A vector with the basis functions. The user owns all the pointers.
+ */
 std::vector<Base::BaseBasisFunction*> createDGBasisFunctions2DNedelec(
     std::size_t order);
 }  // namespace Utilities

--- a/kernel/Utilities/BasisFunctions2DNedelec.h
+++ b/kernel/Utilities/BasisFunctions2DNedelec.h
@@ -47,7 +47,7 @@ namespace hpgem {
 namespace Base {
 class BaseBasisFunction;
 class BasisFunctionSet;
-}
+}  // namespace Base
 
 namespace Utilities {
 

--- a/kernel/Utilities/BasisFunctionsPiecewiseConstant.cpp
+++ b/kernel/Utilities/BasisFunctionsPiecewiseConstant.cpp
@@ -57,7 +57,11 @@ class PiecewiseConstant1 : public Base::BaseBasisFunction {
 };
 
 void addPiecewiseConstantBasisFunction1D(Base::BasisFunctionSet& set) {
-    set.addBasisFunction(new PiecewiseConstant1());
+    set.addBasisFunction(createPiecewiseConstant1D());
+}
+
+Base::BaseBasisFunction* createPiecewiseConstant1D() {
+    return new PiecewiseConstant1();
 }
 
 class PiecewiseConstant2 : public Base::BaseBasisFunction {
@@ -75,8 +79,12 @@ class PiecewiseConstant2 : public Base::BaseBasisFunction {
     }
 };
 
+Base::BaseBasisFunction* createPiecewiseConstant2D() {
+    return new PiecewiseConstant2();
+}
+
 void addPiecewiseConstantBasisFunction2D(Base::BasisFunctionSet& set) {
-    set.addBasisFunction(new PiecewiseConstant2());
+    set.addBasisFunction(createPiecewiseConstant2D());
 }
 
 class PiecewiseConstant3 : public Base::BaseBasisFunction {

--- a/kernel/Utilities/BasisFunctionsPiecewiseConstant.h
+++ b/kernel/Utilities/BasisFunctionsPiecewiseConstant.h
@@ -42,6 +42,7 @@
 namespace hpgem {
 
 namespace Base {
+class BaseBasisFunction;
 class BasisFunctionSet;
 }
 
@@ -51,6 +52,11 @@ void addPiecewiseConstantBasisFunction1D(Base::BasisFunctionSet &set);
 void addPiecewiseConstantBasisFunction2D(Base::BasisFunctionSet &set);
 void addPiecewiseConstantBasisFunction3D(Base::BasisFunctionSet &set);
 void addPiecewiseConstantBasisFunction4D(Base::BasisFunctionSet &set);
+
+/// Create basis function
+Base::BaseBasisFunction *createPiecewiseConstant1D();
+Base::BaseBasisFunction *createPiecewiseConstant2D();
+
 }  // namespace Utilities
 
 }  // namespace hpgem

--- a/kernel/Utilities/BasisFunctionsPiecewiseConstant.h
+++ b/kernel/Utilities/BasisFunctionsPiecewiseConstant.h
@@ -44,7 +44,7 @@ namespace hpgem {
 namespace Base {
 class BaseBasisFunction;
 class BasisFunctionSet;
-}
+}  // namespace Base
 
 namespace Utilities {
 /// Add the piecewise constant for 1D to the basis function set

--- a/tests/unit/Utilities/020Nedelect2D_UnitTest.cpp
+++ b/tests/unit/Utilities/020Nedelect2D_UnitTest.cpp
@@ -1,0 +1,171 @@
+/*
+ This file forms part of hpGEM. This package has been developed over a number of
+ years by various people at the University of Twente and a full list of
+ contributors can be found at http://hpgem.org/about-the-code/team
+
+ This code is distributed using BSD 3-Clause License. A copy of which can found
+ below.
+
+
+ Copyright (c) 2020, University of Twente
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation
+ and/or other materials provided with the distribution.
+
+ 3. Neither the name of the copyright holder nor the names of its contributors
+ may be used to endorse or promote products derived from this software without
+ specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "Utilities/BasisFunctions2DNedelec.h"
+#include "Integration/QuadratureRules/AllGaussQuadratureRules.h"
+#include "Geometry/ReferenceTriangle.h"
+#include "Base/BasisFunctionSet.h"
+#include "../catch.hpp"
+
+using namespace hpgem;
+
+TEST_CASE("Nedelec 2D: Basic properties", "[Nedelec2D]") {
+    auto p = GENERATE(1, 2, 3, 4);
+    auto* bfSet = Utilities::createDGBasisFunctionSet2DNedelec(p);
+
+    REQUIRE(bfSet->getOrder() == p);
+    // There should be p*(p+2) basis functions
+    REQUIRE(bfSet->size() == p * (p + 2));
+}
+
+TEST_CASE("Nedelec 2D: trace values", "[Nedelec2D]") {
+    LinearAlgebra::SmallVector<2> tangents[3];
+    Geometry::PointReference<2> sidePoints[3];
+
+    // -y
+    tangents[0][0] = 1.0;
+    tangents[0][1] = 0.0;
+    // x,y
+    tangents[1][0] = 1.0;
+    tangents[1][1] = -1.0;
+    //-x
+    tangents[2][0] = 0.0;
+    tangents[2][1] = -1.0;
+
+    // Random points on the side to prevent hitting an accidental zero
+    sidePoints[0][0] = 1 / M_PI;
+    sidePoints[1][0] = 1 / M_PI;
+    sidePoints[1][1] = 1 - sidePoints[1][0];
+    sidePoints[2][1] = 1 / M_PI;
+
+    // There should be exactly p basis functions that have non zero trace
+    auto p = GENERATE(1, 2, 3, 4);
+    auto* bfSet = Utilities::createDGBasisFunctionSet2DNedelec(p);
+
+    for (std::size_t side = 0; side < 3; ++side) {
+        std::size_t nonZeroTangents = 0;
+        LinearAlgebra::SmallVector<2> val;
+        for (auto& bf : *bfSet) {
+            // Intentional reuse of val to possibly catch when it is not zeroed
+            bf->eval(sidePoints[side], val);
+            if (std::abs(val * tangents[side]) > 1e-5) {
+                nonZeroTangents++;
+            }
+        }
+        REQUIRE(nonZeroTangents == p);
+    }
+}
+
+TEST_CASE("Nedelec 2D: curl values", "[Nedelec2D]") {
+    auto p = GENERATE(1, 2, 3, 4);
+    auto* bfSet = Utilities::createDGBasisFunctionSet2DNedelec(p);
+
+    const double eps = 0.0001;
+    const double margin = eps * 100;
+
+    // Test points so that there is not just an accidental correct point
+    Geometry::PointReference<2> testPoints[3];
+    testPoints[0] = {0.3, 0.1};
+    testPoints[1] = {0.9, 0.01};
+    testPoints[2] = {0.4, 0.4};
+
+    for (auto& testPoint : testPoints) {
+        LinearAlgebra::SmallVector<2> curl;
+        LinearAlgebra::SmallVector<2> val;
+        LinearAlgebra::SmallVector<2> val2;
+        double fydx, fxdy;
+        for (std::size_t i = 0; i < bfSet->size(); ++i) {
+            bfSet->eval(i, testPoint, val);
+            curl = bfSet->evalCurl(i, testPoint);
+
+            CHECK(curl[1] == 0.0);  // By contract
+
+            // Use finite differences to compute the curl
+            LinearAlgebra::SmallVector<2> temp({eps, 0});
+            Geometry::PointReference<2> pdx(testPoint.getCoordinates() + temp);
+            bfSet->eval(i, pdx, val2);
+            fydx = (val2[1] - val[1]) / eps;
+
+            temp[0] = 0.0;
+            temp[1] = eps;
+            Geometry::PointReference<2> pdy(testPoint.getCoordinates() + temp);
+            bfSet->eval(i, pdy, val2);
+            fxdy = (val2[0] - val[0]) / eps;
+            double fdCurl = fydx - fxdy;
+            // Actual check
+            Approx target = Approx(fdCurl).margin(margin);
+            INFO("Curl of bf " << i << " p=" << p);
+            REQUIRE(curl[0] == target);
+        }
+    }
+}
+
+TEST_CASE("Nedelec 2D: Non singular mass matrix") {
+    // Test to see if the mass matrix is non singular
+    auto p = GENERATE(1, 2, 3, 4);
+    auto* bfSet = Utilities::createDGBasisFunctionSet2DNedelec(p);
+
+    auto* quadRule =
+        QuadratureRules::AllGaussQuadratureRules::instance().getRule(
+            &Geometry::ReferenceTriangle::Instance(), p);
+
+    // Mass matrix
+    LinearAlgebra::MiddleSizeMatrix mat(bfSet->size(), bfSet->size());
+    // Manually perform the quadrature.
+    for (std::size_t qPoint = 0; qPoint < quadRule->nrOfPoints(); ++qPoint) {
+        Geometry::PointReference<2> qp = quadRule->getPoint(qPoint);
+        double weight = quadRule->weight(qPoint);
+
+        for (std::size_t i = 0; i < bfSet->size(); ++i) {
+            LinearAlgebra::SmallVector<2> phiI;
+            // Diagonal entry
+            bfSet->eval(i, qp, phiI);
+            mat(i, i) += phiI * phiI * weight;
+            // Off diagonals
+            for (std::size_t j = i + 1; j < bfSet->size(); ++j) {
+                LinearAlgebra::SmallVector<2> phiJ;
+                double val = phiI * phiJ * weight;
+                mat(i, j) += val;
+                mat(j, i) += val;
+            }
+        }
+    }
+    // Check for non singularity by doing a cholesky decomposition
+    INFO("Checking for singular mass matrix for p=" << p)
+    mat.cholesky();
+}

--- a/tests/unit/Utilities/020Nedelect2D_UnitTest.cpp
+++ b/tests/unit/Utilities/020Nedelect2D_UnitTest.cpp
@@ -48,6 +48,7 @@ TEST_CASE("Nedelec 2D: Basic properties", "[Nedelec2D]") {
     auto p = GENERATE(1, 2, 3, 4);
     auto* bfSet = Utilities::createDGBasisFunctionSet2DNedelec(p);
 
+    // Basic self check
     REQUIRE(bfSet->getOrder() == p);
     // There should be p*(p+2) basis functions
     REQUIRE(bfSet->size() == p * (p + 2));
@@ -56,6 +57,10 @@ TEST_CASE("Nedelec 2D: Basic properties", "[Nedelec2D]") {
 TEST_CASE("Nedelec 2D: trace values", "[Nedelec2D]") {
     LinearAlgebra::SmallVector<2> tangents[3];
     Geometry::PointReference<2> sidePoints[3];
+    // Nedelec elements are for H(curl), for conforming elements this requires
+    // continuous tangential part. Hence, they are constructed to have zero
+    // tangential trace on all sides but (at most) 1. For order p there are
+    // exactly p basis functions with non zero trace.
 
     // -y
     tangents[0][0] = 1.0;
@@ -92,6 +97,10 @@ TEST_CASE("Nedelec 2D: trace values", "[Nedelec2D]") {
 }
 
 TEST_CASE("Nedelec 2D: curl values", "[Nedelec2D]") {
+    // Test whether the curl of the basis functions is computed correctly. For
+    // this we compute the curl through Finite differences and compare it with
+    // the value from the basisfunctions.
+
     auto p = GENERATE(1, 2, 3, 4);
     auto* bfSet = Utilities::createDGBasisFunctionSet2DNedelec(p);
 


### PR DESCRIPTION
This replaces the implementation Nédélec basis functions on a triangle so that we can support more than just the lowest order.

These basis functions are used in DGMax, and we currently only support higher order Nédélec functions on tetrahedra. Adding higher order ones in 2D means that we can test codes with higher order basis functions in 2D instead of 3D. This is much cheaper from a computational point of view.