### PR TITLE
Kshift divdgmax eigenvalue

### DIFF
--- a/applications/DG-Max/Algorithms/DivDGMaxEigenvalue.cpp
+++ b/applications/DG-Max/Algorithms/DivDGMaxEigenvalue.cpp
@@ -43,7 +43,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "Utilities/GlobalMatrix.h"
 #include "Utilities/GlobalVector.h"
 
-#include "Utils/KPhaseShift.h"
+#include "Utils/FaceKPhaseShiftBuilder.h"
 
 #include "DGMaxLogger.h"
 

--- a/applications/DG-Max/Algorithms/DivDGMaxEigenvalue.h
+++ b/applications/DG-Max/Algorithms/DivDGMaxEigenvalue.h
@@ -80,12 +80,6 @@ class DivDGMaxEigenvalue : public AbstractEigenvalueSolver<DIM> {
                          const Utilities::GlobalIndexing& index,
                          Vec& waveVecMatrix);
 
-    // TODO: These are directly copied from DGMaxEigenvalue, this is of course
-    // not good programming.
-    std::vector<Base::Face*> findPeriodicBoundaryFaces() const;
-    LinearAlgebra::SmallVector<DIM> boundaryFaceShift(
-        const Base::Face* face) const;
-
     Base::MeshManipulator<DIM>& mesh_;
     typename DivDGMaxDiscretization<DIM>::Stab stab_;
     std::size_t order_;

--- a/applications/DG-Max/Utils/CGDGMatrixKPhaseShiftBuilder.cpp
+++ b/applications/DG-Max/Utils/CGDGMatrixKPhaseShiftBuilder.cpp
@@ -212,6 +212,8 @@ void CGDGMatrixKPhaseShiftBuilder<DIM>::addElementPhaseShift(
         std::iota(rowIndices.begin(), rowIndices.end(), globalProjectorIndex);
         std::iota(colIndices.begin(), colIndices.end(), globalElementIndex);
 
+        checkMatrixSize(matrix, rowIndices.size(), colIndices.size());
+
         out.emplace_back(DGMax::MatrixBlocks(rowIndices, colIndices, matrix),
                          dx);
     }

--- a/applications/DG-Max/Utils/FaceKPhaseShiftBuilder.cpp
+++ b/applications/DG-Max/Utils/FaceKPhaseShiftBuilder.cpp
@@ -128,15 +128,15 @@ KPhaseShiftBlock<DIM> FaceMatrixKPhaseShiftBuilder<DIM>::facePhaseShift(
 
     // Compute vectors with the global indices //
     /////////////////////////////////////////////
-    std::vector<PetscInt> rowIndices(
-        ownedElement->getNumberOfBasisFunctions(0));
-    std::iota(rowIndices.begin(), rowIndices.end(),
-              indexing.getGlobalIndex(ownedElement, 0));
 
-    std::vector<PetscInt> colIndices(
-        otherElement->getNumberOfBasisFunctions(0));
-    std::iota(colIndices.begin(), colIndices.end(),
-              indexing.getGlobalIndex(otherElement, 0));
+    // Using the functionality from GlobalIndexing is only safe for DG type
+    // basis functions, as they are only located on the elements of the mesh.
+    // This is not checked and left up to the user.
+    std::vector<PetscInt> rowIndices = indexing.getGlobalIndices(ownedElement);
+    std::vector<PetscInt> colIndices = indexing.getGlobalIndices(otherElement);
+
+    checkMatrixSize(block1, rowIndices.size(), colIndices.size());
+    checkMatrixSize(block2, colIndices.size(), rowIndices.size());
 
     // Construct the result //
     //////////////////////////

--- a/applications/DG-Max/Utils/KPhaseShiftHelpers.h
+++ b/applications/DG-Max/Utils/KPhaseShiftHelpers.h
@@ -47,6 +47,16 @@ using namespace hpgem;
 
 // Several helper functions needed for implemting KPhase shifts
 
+inline void checkMatrixSize(const LinearAlgebra::MiddleSizeMatrix mat,
+                            std::size_t rows, std::size_t cols) {
+    logger.assert_always(mat.getNumberOfRows() == rows,
+                         "Incorrect number of rows, expected % got %", rows,
+                         mat.getNumberOfRows());
+    logger.assert_always(mat.getNumberOfColumns() == cols,
+                         "Incorrect number of columns, expected % got %", cols,
+                         mat.getNumberOfColumns());
+}
+
 // Given a point x on a (periodic boundary) face, which has coordinates x_l and
 // x_r as seen from the left and right face respectively. Compute the difference
 // x_l - x_r,


### PR DESCRIPTION
Replace the manual phase shifts in `DivDGMaxEigenvalue` with the abstracted approach from `KPhaseShift`.

As can be seen in the diff, this removes a lot of complicated index-fiddling in DivDGMaxEigenvalue.