### PR TITLE
Remove between k-point shift from DivDGMaxEigenvalue

### DIFF
--- a/applications/DG-Max/Algorithms/DivDGMaxEigenvalue.cpp
+++ b/applications/DG-Max/Algorithms/DivDGMaxEigenvalue.cpp
@@ -149,12 +149,6 @@ void DivDGMaxEigenvalue<DIM>::solve(
     error = VecDuplicateVecs(globalVector, numberOfEigenVectors, &eigenVectors);
     CHKERRABORT(PETSC_COMM_WORLD, error);
     int converged = 0;
-
-    Vec waveVec, waveVecConjugate;
-    error = VecDuplicate(globalVector, &waveVec);
-    CHKERRABORT(PETSC_COMM_WORLD, error);
-    error = VecSetUp(waveVec);
-    CHKERRABORT(PETSC_COMM_WORLD, error);
     DGMaxLogger(INFO, "Storage vectors assembled");
 
     //    makeShiftMatrix(dk, stiffnessMatrix.getGlobalIndex(), waveVec);
@@ -183,31 +177,6 @@ void DivDGMaxEigenvalue<DIM>::solve(
         numberOfEigenvalues = driver.getTargetNumberOfEigenvalues();
         DGMaxLogger(INFO, "Solving for k-vector %/%", solve + 1,
                     expectedNumberOfSteps);
-
-        //        if (kpath.dkDidChange(i)) {
-        //            dk = kpath.dk(i);
-        //            //recompute the shifts
-        //            makeShiftMatrix(k,
-        //            stiffnessMatrix.getGlobalIndex(), waveVec); error
-        //            = VecAssemblyBegin(waveVec);
-        //            CHKERRABORT(PETSC_COMM_WORLD, error);
-        //            error = VecAssemblyEnd(waveVec);
-        //            CHKERRABORT(PETSC_COMM_WORLD, error);
-        //            error = VecCopy(waveVec, waveVecConjugate);
-        //            CHKERRABORT(PETSC_COMM_WORLD, error);
-        //            error = VecConjugate(waveVecConjugate);
-        //            CHKERRABORT(PETSC_COMM_WORLD, error);
-        //        }
-        // SH 180216 turned this off
-        // error = EPSGetInvariantSubspace(eigenSolver_, eigenVectors); //Must
-        // be put after EPSSolve? CHKERRABORT(PETSC_COMM_WORLD, error);
-        // SH 180221
-        // error = MatDiagonalScale(product, waveVec, waveVecConjugate);
-        // error = MatDiagonalScale(massMatrix, waveVec, waveVecConjugate);
-        // error = MatDiagonalScale(stiffnessMatrix, waveVec, waveVecConjugate);
-        // error = MatDiagonalScale(massMatrix, waveVecConjugate, waveVec);
-        // error = MatDiagonalScale(stiffnessMatrix, waveVecConjugate, waveVec);
-        // CHKERRABORT(PETSC_COMM_WORLD, error);
 
         // To match the AssemblyBegin and AssemblyEnd of Mat, we need to call
         // them the same number of times on each node. The current, slightly
@@ -269,38 +238,6 @@ void DivDGMaxEigenvalue<DIM>::solve(
 
     error = EPSDestroy(&eigenSolver);
     CHKERRABORT(PETSC_COMM_WORLD, error);
-}
-
-template <std::size_t DIM>
-void DivDGMaxEigenvalue<DIM>::makeShiftMatrix(
-    LinearAlgebra::SmallVector<DIM>& direction,
-    const Utilities::GlobalIndexing& index, Vec& waveVecMatrix) {
-    PetscErrorCode error;
-
-    for (typename Base::MeshManipulator<DIM>::ElementIterator it =
-             mesh_.elementColBegin();
-         it != mesh_.elementColEnd(); ++it) {
-        Geometry::PointPhysical<DIM> centerPhys;
-        const Geometry::PointReference<DIM>& center =
-            (*it)->getReferenceGeometry()->getCenter();
-        centerPhys = (*it)->referenceToPhysical(center);
-        PetscScalar shift = exp(
-            std::complex<double>(0, direction * centerPhys.getCoordinates()));
-
-        std::size_t basisOffset = index.getGlobalIndex(*it, 0);
-        for (std::size_t j = 0; j < (*it)->getNumberOfBasisFunctions(0); ++j) {
-            error = VecSetValue(waveVecMatrix, basisOffset + j, shift,
-                                INSERT_VALUES);
-            CHKERRABORT(PETSC_COMM_WORLD, error);
-        }
-
-        basisOffset = index.getGlobalIndex(*it, 1);
-        for (std::size_t j = 0; j < (*it)->getNumberOfBasisFunctions(1); ++j) {
-            error = VecSetValue(waveVecMatrix, basisOffset + j, shift,
-                                INSERT_VALUES);
-            CHKERRABORT(PETSC_COMM_WORLD, error);
-        }
-    }
 }
 
 template <std::size_t DIM>

--- a/applications/DG-Max/Algorithms/DivDGMaxEigenvalue.cpp
+++ b/applications/DG-Max/Algorithms/DivDGMaxEigenvalue.cpp
@@ -151,18 +151,6 @@ void DivDGMaxEigenvalue<DIM>::solve(
     int converged = 0;
     DGMaxLogger(INFO, "Storage vectors assembled");
 
-    //    makeShiftMatrix(dk, stiffnessMatrix.getGlobalIndex(), waveVec);
-    //    error = VecAssemblyBegin(waveVec);
-    //    CHKERRABORT(PETSC_COMM_WORLD, error);
-    //    error = VecAssemblyEnd(waveVec);
-    //    CHKERRABORT(PETSC_COMM_WORLD, error);
-    //    error = VecDuplicate(waveVec, &waveVecConjugate);
-    //    CHKERRABORT(PETSC_COMM_WORLD, error);
-    //    error = VecCopy(waveVec, waveVecConjugate);
-    //    CHKERRABORT(PETSC_COMM_WORLD, error);
-    //    error = VecConjugate(waveVecConjugate);
-    //    CHKERRABORT(PETSC_COMM_WORLD, error);
-
     std::size_t outputId = 0;
     std::size_t expectedNumberOfSteps = driver.getNumberOfKPoints();
     // For testing

--- a/applications/DG-Max/Algorithms/DivDGMaxEigenvalue.h
+++ b/applications/DG-Max/Algorithms/DivDGMaxEigenvalue.h
@@ -61,10 +61,6 @@ class DivDGMaxEigenvalue : public AbstractEigenvalueSolver<DIM> {
     void extractEigenvalues(const EPS& solver,
                             std::vector<PetscScalar>& result) const;
 
-    void makeShiftMatrix(LinearAlgebra::SmallVector<DIM>& direction,
-                         const Utilities::GlobalIndexing& index,
-                         Vec& waveVecMatrix);
-
     Base::MeshManipulator<DIM>& mesh_;
     typename DivDGMaxDiscretization<DIM>::Stab stab_;
     std::size_t order_;


### PR DESCRIPTION
It was not used and is not expected to give any significant advantage at the moment.