### PR TITLE
Fix the KPhase shifting

### DIFF
--- a/applications/DG-Max/Utils/KPhaseShift.h
+++ b/applications/DG-Max/Utils/KPhaseShift.h
@@ -90,7 +90,6 @@ class KPhaseShiftBlock {
                std::vector<PetscScalar>& storage, Mat mat) const;
 
    private:
-
     /// The blocks that need to be shifted
     MatrixBlocks blocks_;
     /// The distance x for the phase factor e^{ikx}.

--- a/applications/DG-Max/Utils/KPhaseShift.h
+++ b/applications/DG-Max/Utils/KPhaseShift.h
@@ -90,10 +90,6 @@ class KPhaseShiftBlock {
                std::vector<PetscScalar>& storage, Mat mat) const;
 
    private:
-    /// Check for a k-vector if a phase factor dx_ * k is present
-    bool shiftNeeded(LinearAlgebra::SmallVector<DIM> k) const {
-        return std::abs(dx_ * k) > 1e-12;
-    }
 
     /// The blocks that need to be shifted
     MatrixBlocks blocks_;


### PR DESCRIPTION
Because we did not keep track of the previous k-value the shifting was incorrect. This removes it entirely, as it only gives a minor improvement.