### PR TITLE
Remove Global->Local Vector taking real part

### DIFF
--- a/kernel/Utilities/GlobalVector.cpp
+++ b/kernel/Utilities/GlobalVector.cpp
@@ -283,7 +283,7 @@ void GlobalPetscVector::writeTimeIntegrationVector(
             {
                 // Copy the values from data to the localData and update the
                 // running number
-                localData[runningTotal] = std::real(data[elementBasis0 + i]);
+                localData[runningTotal] = data[elementBasis0 + i];
                 ++runningTotal;
             }
 
@@ -300,7 +300,7 @@ void GlobalPetscVector::writeTimeIntegrationVector(
                 {
                     // Copy the values from data to the localData and update the
                     // running number
-                    localData[runningTotal] = std::real(data[faceBasis0 + j]);
+                    localData[runningTotal] = data[faceBasis0 + j];
                     ++runningTotal;
                 }
             }
@@ -317,7 +317,7 @@ void GlobalPetscVector::writeTimeIntegrationVector(
                     // Copy the values from data to the localData and update the
                     // running number
 
-                    localData[runningTotal] = std::real(data[edgeBasis0 + j]);
+                    localData[runningTotal] = data[edgeBasis0 + j];
                     ++runningTotal;
                 }
             }
@@ -337,8 +337,7 @@ void GlobalPetscVector::writeTimeIntegrationVector(
                     {
                         // Copy the values from data to the localData and update
                         // the running number
-                        localData[runningTotal] =
-                            std::real(data[nodeBasis0 + j]);
+                        localData[runningTotal] = data[nodeBasis0 + j];
                         ++runningTotal;
                     }
                 }
@@ -406,7 +405,7 @@ void GlobalPetscVector::writeTimeIntegrationVector(
                 (*it)->getLocalNumberOfBasisFunctions(index);
             int elementBasis0 = indexing_.getGlobalIndex((*it), index);
             for (std::size_t i = 0; i < nElementBasis; ++i) {
-                localData[runningTotal] = std::real(data[elementBasis0 + i]);
+                localData[runningTotal] = data[elementBasis0 + i];
                 ++runningTotal;
             }
 
@@ -417,7 +416,7 @@ void GlobalPetscVector::writeTimeIntegrationVector(
                 int faceBasis0 =
                     indexing_.getGlobalIndex((*it)->getFace(i), index);
                 for (std::size_t j = 0; j < nFaceBasis; ++j) {
-                    localData[runningTotal] = std::real(data[faceBasis0 + j]);
+                    localData[runningTotal] = data[faceBasis0 + j];
                     ++runningTotal;
                 }
             }
@@ -427,7 +426,7 @@ void GlobalPetscVector::writeTimeIntegrationVector(
                 int edgeBasis0 =
                     indexing_.getGlobalIndex((*it)->getEdge(i), index);
                 for (std::size_t j = 0; j < nEdgeBasis; ++j) {
-                    localData[runningTotal] = std::real(data[edgeBasis0 + j]);
+                    localData[runningTotal] = data[edgeBasis0 + j];
                     ++runningTotal;
                 }
             }
@@ -439,8 +438,7 @@ void GlobalPetscVector::writeTimeIntegrationVector(
                     int nodeBasis0 =
                         indexing_.getGlobalIndex((*it)->getNode(i), index);
                     for (std::size_t j = 0; j < nNodeBasis; ++j) {
-                        localData[runningTotal] =
-                            std::real(data[nodeBasis0 + j]);
+                        localData[runningTotal] = data[nodeBasis0 + j];
                         ++runningTotal;
                     }
                 }


### PR DESCRIPTION
Taking a global vector and writing it as local vector (time integration one) did take the real part of the coefficients. This is strange, as
this discards any imaginary part of the solution. This is especially problematic when plotting the solution or locally computing an error, as there the imaginary part will have been discarded.

Search through the history I could not find a reason for taking the real part (though I did remove it unintentionally and undid that at r925-926).