### PR TITLE
Print verbose output on workflow ctest failure

### DIFF
--- a/.github/workflows/Basic.yml
+++ b/.github/workflows/Basic.yml
@@ -27,4 +27,4 @@ jobs:
     - name: make
       run: cmake --build build -- -j4
     - name: test
-      run: cd build && ctest
+      run: cd build && ctest --output-on-failure

--- a/.github/workflows/PETSC_complex.yml
+++ b/.github/workflows/PETSC_complex.yml
@@ -27,4 +27,4 @@ jobs:
     - name: make
       run: cmake --build build -- -j4
     - name: test
-      run: cd build && ctest -V -R DGmax_Vacuum2D_SelfTest && ctest
+      run: cd build && ctest --output-on-failure

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -25,4 +25,4 @@ jobs:
     - name: make
       run: cmake --build build -- -j4
     - name: test
-      run: cd build && ctest
+      run: cd build && ctest --output-on-failure


### PR DESCRIPTION
This to make debugging the result considerably easier, as the current output only shows that a test has failed, but not why.