### PR TITLE
Use higher order output for DGMaxEigen

### DIFF
--- a/applications/DG-Max/Programs/DGMaxEigen.cpp
+++ b/applications/DG-Max/Programs/DGMaxEigen.cpp
@@ -164,8 +164,9 @@ class DGMaxEigenDriver : public AbstractEigenvalueSolverDriver<DIM> {
                 }
 
                 outFile << "eigenfield-" << currentPoint_ << "-field-" << i;
-                Output::VTKSpecificTimeWriter<DIM> writer(outFile.str(),
-                                                          result.getMesh());
+                // Note the zero for timelevel is unused.
+                Output::VTKSpecificTimeWriter<DIM> writer(
+                    outFile.str(), result.getMesh(), 0, order.getValue());
                 result.writeField(i, writer);
             }
         }


### PR DESCRIPTION
Pretty self explanatory. The original use for #80, now the code to actually use it in practice.