### PR TITLE
Cleanup namespaces and includes in the Preprocessor

### DIFF
--- a/applications/Preprocessor/centaur.cpp
+++ b/applications/Preprocessor/centaur.cpp
@@ -42,9 +42,9 @@
 #include "centaur.h"
 #include "Logger.h"
 
-using namespace hpgem;
-
 namespace Preprocessor {
+
+using namespace hpgem;
 
 /*
  * General notes.

--- a/applications/Preprocessor/centaur.h
+++ b/applications/Preprocessor/centaur.h
@@ -48,9 +48,9 @@
 #include <string>
 #include <map>
 
-using namespace hpgem;
-
 namespace Preprocessor {
+
+using namespace hpgem;
 
 class CentaurReader : public MeshSource {
    public:

--- a/applications/Preprocessor/customIterator.h
+++ b/applications/Preprocessor/customIterator.h
@@ -48,9 +48,9 @@
 #include <utility>
 #include <Logger.h>
 
-using namespace hpgem;
-
 namespace Preprocessor {
+
+using namespace hpgem;
 
 namespace Detail {
 template <bool... predicates>

--- a/applications/Preprocessor/customVector.h
+++ b/applications/Preprocessor/customVector.h
@@ -44,9 +44,9 @@
 #include <Logger.h>
 #include "customIterator.h"
 
-using namespace hpgem;
-
 namespace Preprocessor {
+
+using namespace hpgem;
 
 /**
  * @brief A thing that behaves like vector but can also store a bit of data

--- a/applications/Preprocessor/elementShape.h
+++ b/applications/Preprocessor/elementShape.h
@@ -42,9 +42,10 @@
 #include <cstddef>
 #include <vector>
 #include "Logger.h"
-#include "customVector.h"
 
 namespace Preprocessor {
+
+using namespace hpgem;
 
 template <std::size_t dimension>
 class ElementShape;
@@ -465,7 +466,5 @@ const std::vector<const ElementShape<3>*> defaultShapes<3> = {
 }  // namespace Preprocessor
 
 #include <elementShape_impl.h>
-
-using namespace hpgem;
 
 #endif  // HPGEM_APP_ELEMENTSHAPE_H

--- a/applications/Preprocessor/elementShape_impl.h
+++ b/applications/Preprocessor/elementShape_impl.h
@@ -40,12 +40,12 @@
 #include <numeric>
 #include "elementShape.h"
 
-using namespace hpgem;
+namespace Preprocessor {
 
 template <std::size_t dimension>
 template <int entityDimension>
 std::enable_if_t<(entityDimension < 0), std::size_t>
-    Preprocessor::ElementShape<dimension>::getNumberOfEntities() const {
+    ElementShape<dimension>::getNumberOfEntities() const {
     if (entityDimension + dimension < 0) return 0;
     return getNumberOfEntities<entityDimension + dimension>();
 }
@@ -53,7 +53,7 @@ std::enable_if_t<(entityDimension < 0), std::size_t>
 template <std::size_t dimension>
 template <int entityDimension>
 std::enable_if_t<(entityDimension >= dimension), std::size_t>
-    Preprocessor::ElementShape<dimension>::getNumberOfEntities() const {
+    ElementShape<dimension>::getNumberOfEntities() const {
     if (entityDimension > dimension) return 0;
     return 1;
 }
@@ -62,14 +62,13 @@ template <std::size_t dimension>
 template <int entityDimension>
 std::enable_if_t<(entityDimension >= 0 && entityDimension < dimension),
                  std::size_t>
-    Preprocessor::ElementShape<dimension>::getNumberOfEntities() const {
+    ElementShape<dimension>::getNumberOfEntities() const {
     return shapeData.template getEntityShapes<entityDimension>().size();
 }
 
 template <std::size_t dimension>
 template <int entityDimension>
-auto Preprocessor::ElementShape<dimension>::getBoundaryShape(
-    std::size_t entityIndex) const
+auto ElementShape<dimension>::getBoundaryShape(std::size_t entityIndex) const
     -> std::enable_if_t<(entityDimension < 0),
                         const ShapeType<entityDimension>*> {
     logger.assert_debug(entityDimension + dimension >= 0,
@@ -80,8 +79,7 @@ auto Preprocessor::ElementShape<dimension>::getBoundaryShape(
 
 template <std::size_t dimension>
 template <int entityDimension>
-auto Preprocessor::ElementShape<dimension>::getBoundaryShape(
-    std::size_t entityIndex) const
+auto ElementShape<dimension>::getBoundaryShape(std::size_t entityIndex) const
     -> std::enable_if_t<(entityDimension >= dimension),
                         const ShapeType<entityDimension>*> {
     logger.assert_debug(entityDimension == dimension,
@@ -95,8 +93,7 @@ auto Preprocessor::ElementShape<dimension>::getBoundaryShape(
 
 template <std::size_t dimension>
 template <int entityDimension>
-auto Preprocessor::ElementShape<dimension>::getBoundaryShape(
-    std::size_t entityIndex) const
+auto ElementShape<dimension>::getBoundaryShape(std::size_t entityIndex) const
     -> std::enable_if_t<(entityDimension >= 0 && entityDimension < dimension),
                         const ShapeType<entityDimension>*> {
     logger.assert_debug(entityIndex < getNumberOfEntities<entityDimension>(),
@@ -110,7 +107,7 @@ auto Preprocessor::ElementShape<dimension>::getBoundaryShape(
 template <std::size_t dimension>
 template <int entityDimension, int targetDimension>
 std::enable_if_t<(entityDimension < 0), std::vector<std::size_t>>
-    Preprocessor::ElementShape<dimension>::getAdjacentEntities(
+    ElementShape<dimension>::getAdjacentEntities(
         std::size_t entityIndex) const {
     logger.assert_debug(entityDimension + dimension >= 0,
                         "This shape is not bounded by shapes of dimension %",
@@ -123,7 +120,7 @@ template <std::size_t dimension>
 template <int entityDimension, int targetDimension>
 std::enable_if_t<(targetDimension < 0 && entityDimension >= 0),
                  std::vector<std::size_t>>
-    Preprocessor::ElementShape<dimension>::getAdjacentEntities(
+    ElementShape<dimension>::getAdjacentEntities(
         std::size_t entityIndex) const {
     if (targetDimension + dimension < 0) return {};
     return getAdjacentEntities<entityDimension, targetDimension + dimension>(
@@ -136,7 +133,7 @@ std::enable_if_t<(entityDimension >= 0 && targetDimension >= 0 &&
                   (entityDimension >= dimension ||
                    targetDimension >= dimension)),
                  std::vector<std::size_t>>
-    Preprocessor::ElementShape<dimension>::getAdjacentEntities(
+    ElementShape<dimension>::getAdjacentEntities(
         std::size_t entityIndex) const {
     logger.assert_debug(entityDimension <= dimension,
                         "This shape is not bounded by shapes of dimension %",
@@ -159,7 +156,7 @@ template <int entityDimension, int targetDimension>
 std::enable_if_t<(entityDimension >= 0 && entityDimension < dimension &&
                   targetDimension >= 0 && targetDimension < dimension),
                  std::vector<std::size_t>>
-    Preprocessor::ElementShape<dimension>::getAdjacentEntities(
+    ElementShape<dimension>::getAdjacentEntities(
         std::size_t entityIndex) const {
     logger.assert_debug(entityIndex < getNumberOfEntities<entityDimension>(),
                         "This shape is bounded by only % shapes of dimension "
@@ -172,7 +169,7 @@ std::enable_if_t<(entityDimension >= 0 && entityDimension < dimension &&
 
 template <std::size_t dimension>
 template <std::size_t d, std::size_t shapeDimension>
-bool Preprocessor::ElementShape<dimension>::checkSingleShape(
+bool ElementShape<dimension>::checkSingleShape(
     const ElementShape<shapeDimension>* boundingShape,
     std::vector<std::size_t> boundaryNodes, std::size_t currentIndex,
     tag<d>) const {
@@ -218,7 +215,7 @@ bool Preprocessor::ElementShape<dimension>::checkSingleShape(
 
 template <std::size_t dimension>
 template <std::size_t shapeDimension>
-bool Preprocessor::ElementShape<dimension>::checkSingleShape(
+bool ElementShape<dimension>::checkSingleShape(
     const ElementShape<shapeDimension>* boundingShape,
     std::vector<std::size_t> boundaryNodes, std::size_t currentIndex,
     tag<0>) const {
@@ -263,7 +260,7 @@ bool Preprocessor::ElementShape<dimension>::checkSingleShape(
 
 template <std::size_t dimension>
 template <std::size_t d>
-bool Preprocessor::ElementShape<dimension>::checkBoundaryShape(tag<d>) const {
+bool ElementShape<dimension>::checkBoundaryShape(tag<d>) const {
     if (shapeData.template getEntityShapes<d>().size() !=
         shapeData.template getAdjacentShapes<d>()[0].size()) {
         logger(ERROR,
@@ -304,7 +301,7 @@ bool Preprocessor::ElementShape<dimension>::checkBoundaryShape(tag<d>) const {
 }
 
 template <std::size_t dimension>
-bool Preprocessor::ElementShape<dimension>::checkBoundaryShape(tag<0>) const {
+bool ElementShape<dimension>::checkBoundaryShape(tag<0>) const {
     if (shapeData.template getEntityShapes<0>().size() !=
         shapeData.template getAdjacentShapes<0>()[0].size()) {
         logger(ERROR,
@@ -339,8 +336,8 @@ bool Preprocessor::ElementShape<dimension>::checkBoundaryShape(tag<0>) const {
 
 template <std::size_t dimension>
 template <std::size_t entityDimension, std::size_t targetDimension>
-void Preprocessor::ElementShape<dimension>::completeSubShapes(
-    tag<entityDimension>, tag<targetDimension>) {
+void ElementShape<dimension>::completeSubShapes(tag<entityDimension>,
+                                                tag<targetDimension>) {
     shapeData.template getAdjacentShapes<entityDimension>()[targetDimension]
         .resize(getNumberOfEntities<entityDimension>());
     for (std::size_t entityIndex = 0;
@@ -403,7 +400,8 @@ void Preprocessor::ElementShape<dimension>::completeSubShapes(
 
 template <std::size_t dimension>
 template <std::size_t entityDimension>
-void Preprocessor::ElementShape<dimension>::completeSubShapes(
-    tag<entityDimension>, tag<0>) {
+void ElementShape<dimension>::completeSubShapes(tag<entityDimension>, tag<0>) {
     completeSubShapes(tag<entityDimension - 1>{}, tag<dimension - 1>{});
 }
+
+}  // namespace Preprocessor

--- a/applications/Preprocessor/hpgem.cpp
+++ b/applications/Preprocessor/hpgem.cpp
@@ -40,9 +40,9 @@
 #include "hpgem.h"
 #include "Logger.h"
 
-using namespace hpgem;
-
 namespace Preprocessor {
+
+using namespace hpgem;
 
 // this is clearly not a bool so std::vector<Bool> will not behave as badly as
 // std::vector<bool>

--- a/applications/Preprocessor/hpgem.h
+++ b/applications/Preprocessor/hpgem.h
@@ -45,9 +45,9 @@
 #include <string>
 #include <fstream>
 
-using namespace hpgem;
-
 namespace Preprocessor {
+
+using namespace hpgem;
 
 class PrivateReader : public MeshSource {
    public:

--- a/applications/Preprocessor/main.cpp
+++ b/applications/Preprocessor/main.cpp
@@ -97,7 +97,7 @@ void printMeshStatistics(const Preprocessor::Mesh<dimension>& mesh) {
 
 template <std::size_t dimension>
 Preprocessor::MeshData<idx_t, dimension, dimension> partitionMesh(
-    Preprocessor::Mesh<dimension> mesh) {
+    Preprocessor::Mesh<dimension>& mesh) {
     Preprocessor::MeshData<idx_t, dimension, dimension> partitionID(&mesh);
     idx_t numberOfProcessors = targetMpiCount.getValue();
     if (numberOfProcessors > 1) {

--- a/applications/Preprocessor/main.cpp
+++ b/applications/Preprocessor/main.cpp
@@ -96,9 +96,8 @@ void printMeshStatistics(const Preprocessor::Mesh<dimension>& mesh) {
 }
 
 template <std::size_t dimension>
-void processMesh(Preprocessor::Mesh<dimension> mesh) {
-    printMeshStatistics(mesh);
-
+Preprocessor::MeshData<idx_t, dimension, dimension> partitionMesh(
+    Preprocessor::Mesh<dimension> mesh) {
     Preprocessor::MeshData<idx_t, dimension, dimension> partitionID(&mesh);
     idx_t numberOfProcessors = targetMpiCount.getValue();
     if (numberOfProcessors > 1) {
@@ -147,6 +146,16 @@ void processMesh(Preprocessor::Mesh<dimension> mesh) {
             "Please install metis if you want to generate a distributed mesh");
 #endif
     }
+    return partitionID;
+}
+
+template <std::size_t dimension>
+void processMesh(Preprocessor::Mesh<dimension> mesh) {
+    printMeshStatistics(mesh);
+
+    Preprocessor::MeshData<idx_t, dimension, dimension> partitionID =
+        partitionMesh(mesh);
+    idx_t numberOfProcessors = targetMpiCount.getValue();
     Preprocessor::outputMesh(mesh, partitionID, numberOfProcessors);
 }
 

--- a/applications/Preprocessor/mesh.h
+++ b/applications/Preprocessor/mesh.h
@@ -39,7 +39,6 @@
 #ifndef HPGEM_APP_MESH_H
 #define HPGEM_APP_MESH_H
 
-#include "Base/ConstIterableWrapper.h"
 #include "LinearAlgebra/SmallVector.h"
 #include "elementShape.h"
 #include "MeshSource.h"
@@ -715,11 +714,10 @@ Mesh<dimension> readFile(MeshSource& file) {
     }
     logger.assert_debug(result.isValid(), "Unspecified problem with the mesh");
     return result;
-};
+}
+
 }  // namespace Preprocessor
 
 #include "mesh_impl.h"
-
-using namespace hpgem;
 
 #endif  // HPGEM_APP_MESH_H

--- a/applications/Preprocessor/meshData.h
+++ b/applications/Preprocessor/meshData.h
@@ -42,9 +42,9 @@
 #include <cstddef>
 #include "mesh.h"
 
-using namespace hpgem;
-
 namespace Preprocessor {
+
+using namespace hpgem;
 
 // todo: conversion operators
 

--- a/applications/Preprocessor/mesh_impl.h
+++ b/applications/Preprocessor/mesh_impl.h
@@ -38,8 +38,6 @@
 
 #include "mesh.h"
 
-using namespace hpgem;
-
 namespace Preprocessor {
 
 template <std::size_t entityDimension, std::size_t meshDimension>

--- a/applications/Preprocessor/output.h
+++ b/applications/Preprocessor/output.h
@@ -43,7 +43,7 @@
 #include "mesh.h"
 #include "meshData.h"
 
-auto& outputFileName = Base::register_argument<std::string>(
+auto& outputFileName = hpgem::Base::register_argument<std::string>(
     '\0', "outFile", "Name of your output file (input for hpGEM)", false,
     "mesh.hpGEM");
 
@@ -55,7 +55,5 @@ void outputMesh(Mesh<dimension>& mesh,
 }
 
 #include "output_impl.h"
-
-using namespace hpgem;
 
 #endif  // HPGEM_APP_OUTPUT_H

--- a/applications/Preprocessor/output_impl.h
+++ b/applications/Preprocessor/output_impl.h
@@ -42,6 +42,8 @@
 #include <set>
 #include <map>
 
+namespace Preprocessor {
+
 using namespace hpgem;
 
 namespace Detail {
@@ -50,26 +52,26 @@ struct tag {};
 
 template <std::size_t dimension>
 void printOtherEntityCounts(std::ofstream& output,
-                            const Preprocessor::Mesh<dimension>& mesh, tag<0>) {
+                            const Mesh<dimension>& mesh, tag<0>) {
 }
 
 template <std::size_t d, std::size_t dimension>
 void printOtherEntityCounts(std::ofstream& output,
-                            const Preprocessor::Mesh<dimension>& mesh, tag<d>) {
+                            const Mesh<dimension>& mesh, tag<d>) {
     output << " " << mesh.template getNumberOfEntities<d>();
     printOtherEntityCounts(output, mesh, tag<d - 1>{});
 }
 
 template <std::size_t dimension, typename indexType>
 void printOtherEntities(
-    std::ofstream& output, const Preprocessor::Mesh<dimension>& mesh,
-    Preprocessor::MeshData<indexType, dimension, dimension>& partitions,
+    std::ofstream& output, const Mesh<dimension>& mesh,
+    MeshData<indexType, dimension, dimension>& partitions,
     tag<0>) {}
 
 template <std::size_t d, std::size_t dimension, typename indexType>
 void printOtherEntities(
-    std::ofstream& output, const Preprocessor::Mesh<dimension>& mesh,
-    Preprocessor::MeshData<indexType, dimension, dimension>& partitions,
+    std::ofstream& output, const Mesh<dimension>& mesh,
+    MeshData<indexType, dimension, dimension>& partitions,
     tag<d>) {
     for (auto entity : mesh.template getEntities<d>()) {
         std::set<std::size_t> localPartitions;
@@ -95,7 +97,7 @@ void printOtherEntities(
 }  // namespace Detail
 
 template <typename indexType, std::size_t dimension>
-void Preprocessor::outputMesh(
+void outputMesh(
     Mesh<dimension>& mesh, MeshData<indexType, dimension, dimension> partitions,
     std::size_t numberOfPartitions) {
     if (mesh.getNumberOfNodes() == 0) {
@@ -106,7 +108,7 @@ void Preprocessor::outputMesh(
     output << "mesh 1" << std::endl;
     output << mesh.getNumberOfNodes() << " " << mesh.getNumberOfElements()
            << " " << dimension;
-    printOtherEntityCounts(output, mesh, ::Detail::tag<dimension - 1>{});
+    printOtherEntityCounts(output, mesh, Detail::tag<dimension - 1>{});
     output << std::endl;
     std::size_t reservedSpace =
         std::max(std::log10(mesh.getNumberOfNodes()), 0.) + 2;
@@ -189,10 +191,12 @@ void Preprocessor::outputMesh(
         output << std::endl;
     }
     printOtherEntities(output, mesh, partitions,
-                       ::Detail::tag<dimension - 1>{});
+                       Detail::tag<dimension - 1>{});
     output.seekp(partitionInformation);
     for (std::size_t i = 0; i < numberOfPartitions; ++i) {
         output << partitionData[i] << " ";
     }
     output.close();
 }
+
+}  // namespace Preprocessor

--- a/applications/Preprocessor/output_impl.h
+++ b/applications/Preprocessor/output_impl.h
@@ -51,28 +51,25 @@ template <std::size_t d>
 struct tag {};
 
 template <std::size_t dimension>
-void printOtherEntityCounts(std::ofstream& output,
-                            const Mesh<dimension>& mesh, tag<0>) {
-}
+void printOtherEntityCounts(std::ofstream& output, const Mesh<dimension>& mesh,
+                            tag<0>) {}
 
 template <std::size_t d, std::size_t dimension>
-void printOtherEntityCounts(std::ofstream& output,
-                            const Mesh<dimension>& mesh, tag<d>) {
+void printOtherEntityCounts(std::ofstream& output, const Mesh<dimension>& mesh,
+                            tag<d>) {
     output << " " << mesh.template getNumberOfEntities<d>();
     printOtherEntityCounts(output, mesh, tag<d - 1>{});
 }
 
 template <std::size_t dimension, typename indexType>
-void printOtherEntities(
-    std::ofstream& output, const Mesh<dimension>& mesh,
-    MeshData<indexType, dimension, dimension>& partitions,
-    tag<0>) {}
+void printOtherEntities(std::ofstream& output, const Mesh<dimension>& mesh,
+                        MeshData<indexType, dimension, dimension>& partitions,
+                        tag<0>) {}
 
 template <std::size_t d, std::size_t dimension, typename indexType>
-void printOtherEntities(
-    std::ofstream& output, const Mesh<dimension>& mesh,
-    MeshData<indexType, dimension, dimension>& partitions,
-    tag<d>) {
+void printOtherEntities(std::ofstream& output, const Mesh<dimension>& mesh,
+                        MeshData<indexType, dimension, dimension>& partitions,
+                        tag<d>) {
     for (auto entity : mesh.template getEntities<d>()) {
         std::set<std::size_t> localPartitions;
         output << entity.getNumberOfElements() << " ";
@@ -97,9 +94,9 @@ void printOtherEntities(
 }  // namespace Detail
 
 template <typename indexType, std::size_t dimension>
-void outputMesh(
-    Mesh<dimension>& mesh, MeshData<indexType, dimension, dimension> partitions,
-    std::size_t numberOfPartitions) {
+void outputMesh(Mesh<dimension>& mesh,
+                MeshData<indexType, dimension, dimension> partitions,
+                std::size_t numberOfPartitions) {
     if (mesh.getNumberOfNodes() == 0) {
         logger(WARN, "outputting empty mesh");
     }
@@ -190,8 +187,7 @@ void outputMesh(
         }
         output << std::endl;
     }
-    printOtherEntities(output, mesh, partitions,
-                       Detail::tag<dimension - 1>{});
+    printOtherEntities(output, mesh, partitions, Detail::tag<dimension - 1>{});
     output.seekp(partitionInformation);
     for (std::size_t i = 0; i < numberOfPartitions; ++i) {
         output << partitionData[i] << " ";

--- a/applications/Preprocessor/unstructuredFile.h
+++ b/applications/Preprocessor/unstructuredFile.h
@@ -49,9 +49,10 @@
 #include <ios>
 #include "Logger.h"
 
+namespace Preprocessor {
+
 using namespace hpgem;
 
-namespace Preprocessor {
 template <typename inStream>
 class UnstructuredInputStream {
     // when needed this can be reimplemented to look like moveFunction (and not


### PR DESCRIPTION
This moves the `using namespace hpgem` into the Preprocessor namespace
scope. For that it was required to introduce this namespace explicitly
in some of the cpp files.

Additionally, some unused include statements were removed.