### PR TITLE
Expand the correctly calculated owningElements

### DIFF
--- a/kernel/Base/Edge.cpp
+++ b/kernel/Base/Edge.cpp
@@ -133,7 +133,7 @@ Element* Edge::getOwningElement() const {
         if (!safe) {
             // The edge does not have a link to the nodes at the ends. We need
             // to go through one of the adjacent elements.
-            const std::size_t ELEM_LID = 0; // Local ID of the element
+            const std::size_t ELEM_LID = 0;  // Local ID of the element
             const Element* element = elements_[ELEM_LID];
             const Geometry::ReferenceGeometry* referenceGeometry =
                 element->getReferenceGeometry();

--- a/kernel/Base/Edge.cpp
+++ b/kernel/Base/Edge.cpp
@@ -131,12 +131,16 @@ Element* Edge::getOwningElement() const {
         }
         // The expensive check going via both the nodes
         if (!safe) {
-            const Element* element = elements_[0];
+            // The edge does not have a link to the nodes at the ends. We need
+            // to go through one of the adjacent elements.
+            const std::size_t ELEM_LID = 0; // Local ID of the element
+            const Element* element = elements_[ELEM_LID];
             const Geometry::ReferenceGeometry* referenceGeometry =
                 element->getReferenceGeometry();
+            // The nodes corresponding to the edge
             std::vector<std::size_t> nodeIds =
                 referenceGeometry->getCodim2EntityLocalIndices(
-                    localEdgeNumbers_[0]);
+                    localEdgeNumbers_[ELEM_LID]);
             for (std::size_t nodeId : nodeIds) {
                 const Node* node = element->getNode(nodeId);
                 for (const Element* nodeElement : node->getElements()) {

--- a/kernel/Base/Face.h
+++ b/kernel/Base/Face.h
@@ -361,12 +361,7 @@ class Face final : public Geometry::FaceGeometry, public FaceData {
 
     /// The element owning this face, only valid if the face is owned by the
     /// current processor
-    Element* getOwningElement() const {
-        logger.assert_debug(isOwnedByCurrentProcessor(),
-                            "Owning element is only accurate when owned by the "
-                            "current processor");
-        return elementLeft_;
-    }
+    Element* getOwningElement() const;
 
    private:
     Element* elementLeft_;


### PR DESCRIPTION
Work from an old branch. Each face, edge and node has an owner. If we own the part then we are certain about the owner, but for parts in the ghost layer we may have insufficient data to determine the owner with certainty. To prevent accidents from reporting the wrong owner, a rather conservative check was added to each of the parts. That is, a fail safe design was used, better report that it is not possible to determine the owner than report the wrong one.

Improved knowledge about the mesh, and ghost layer specifically, allowed widening the number of cases where we could determine the owner of a part with certainty.