### PR TITLE
Fix zone assignment in preprocessor

### DIFF
--- a/applications/Preprocessor/lib/hpgem.cpp
+++ b/applications/Preprocessor/lib/hpgem.cpp
@@ -223,7 +223,7 @@ class StructuredReader : public PrivateReader {
             }
         };
         MeshSource::Element first;
-        first.zoneName = "Main"; // Only one default zone
+        first.zoneName = "Main";  // Only one default zone
         increment(first);
         std::size_t totalNumberOfElements = 1;
         for (std::size_t i = 0; i < loopIndices.size(); ++i) {

--- a/applications/Preprocessor/lib/hpgem.cpp
+++ b/applications/Preprocessor/lib/hpgem.cpp
@@ -223,6 +223,7 @@ class StructuredReader : public PrivateReader {
             }
         };
         MeshSource::Element first;
+        first.zoneName = "Main"; // Only one default zone
         increment(first);
         std::size_t totalNumberOfElements = 1;
         for (std::size_t i = 0; i < loopIndices.size(); ++i) {

--- a/applications/Preprocessor/lib/mesh.h
+++ b/applications/Preprocessor/lib/mesh.h
@@ -710,6 +710,8 @@ Mesh<dimension> readFile(MeshSource& file) {
         }
     }
     for (auto element : file.getElements()) {
+        logger.assert_always(!element.zoneName.empty(),
+                             "Element without a zone name");
         result.addElement(element.coordinateIds, element.zoneName);
     }
     logger.assert_debug(result.isValid(), "Unspecified problem with the mesh");
@@ -743,6 +745,8 @@ Mesh<dimension> fromMeshSource(MeshSource2& file) {
     }
     // Add all the elements
     for (auto element : file.getElements()) {
+        logger.assert_always(!element.zoneName.empty(),
+                             "Element without a zone name");
         result.addElement(element.coordinateIds, element.zoneName);
     }
     logger.assert_debug(result.isValid(), "Unspecified problem with the mesh");

--- a/applications/Preprocessor/lib/mesh_impl.h
+++ b/applications/Preprocessor/lib/mesh_impl.h
@@ -382,7 +382,7 @@ template <std::size_t dimension>
 void Mesh<dimension>::addElement(std::vector<std::size_t> nodeCoordinateIDs,
                                  const std::string& zoneName) {
     std::size_t elementID = elementsList.size();
-    Element<dimension> newElement{this, elementID, 0};
+    Element<dimension> newElement{this, elementID, getZoneId(zoneName)};
     newElement.setGeometry(findGeometry(nodeCoordinateIDs.size()));
     for (auto coordinateID : nodeCoordinateIDs) {
         std::size_t nodeID = coordinates[coordinateID].nodeIndex;


### PR DESCRIPTION
Fixes to problems found when trying to use #103 and #109 together to use the new mesh format.

Fixes:
 - The zone was passed from the MeshSource to addElement(), but the latter did not actually use it.
 - The elements generated by the structured mesh generator did not have any zone information.

As backup to the second problem a check is placed that checks if an actual zone is present.