### PR TITLE
Fixed dimension ReferenceToPhysicalMapping (uses #121)

### DIFF
--- a/kernel/Base/Element.h
+++ b/kernel/Base/Element.h
@@ -821,7 +821,8 @@ std::vector<LinearAlgebra::SmallVector<DIM>> Element::getSolutionGradient(
     std::vector<std::size_t> numberOfBasisFunctions =
         std::vector<std::size_t>(numberOfUnknowns, 0);
     std::vector<LinearAlgebra::SmallVector<DIM>> solution(numberOfUnknowns);
-    auto jacobean = getReferenceToPhysicalMap()->calcJacobian(p);
+    auto jacobean =
+        getReferenceToPhysicalMap()->castDimension<DIM>().calcJacobian(p);
     jacobean = jacobean.transpose();
 
     LinearAlgebra::MiddleSizeVector data =

--- a/kernel/Geometry/ElementGeometry.cpp
+++ b/kernel/Geometry/ElementGeometry.cpp
@@ -116,12 +116,12 @@ ElementGeometry::~ElementGeometry() {
 
 /// Returns a pointer to the referenceToPhysicalMapping
 
-const MappingReferenceToPhysical* ElementGeometry::getReferenceToPhysicalMap()
+const MappingReferenceToPhysicalBase* ElementGeometry::getReferenceToPhysicalMap()
     const {
     return referenceToPhysicalMapping_;
 }
 
-MappingReferenceToPhysical* ElementGeometry::getReferenceToPhysicalMap() {
+MappingReferenceToPhysicalBase* ElementGeometry::getReferenceToPhysicalMap() {
     return referenceToPhysicalMapping_;
 }
 

--- a/kernel/Geometry/ElementGeometry.cpp
+++ b/kernel/Geometry/ElementGeometry.cpp
@@ -116,8 +116,8 @@ ElementGeometry::~ElementGeometry() {
 
 /// Returns a pointer to the referenceToPhysicalMapping
 
-const MappingReferenceToPhysicalBase* ElementGeometry::getReferenceToPhysicalMap()
-    const {
+const MappingReferenceToPhysicalBase*
+    ElementGeometry::getReferenceToPhysicalMap() const {
     return referenceToPhysicalMapping_;
 }
 

--- a/kernel/Geometry/ElementGeometry.cpp
+++ b/kernel/Geometry/ElementGeometry.cpp
@@ -69,6 +69,7 @@ ElementGeometry::ElementGeometry(const ElementGeometry& other)
                                             // default, to  enable it one needs
                                             // to call enableRefinement
 {
+    referenceToPhysicalMapping_ = other.referenceToPhysicalMapping_->copy();
     // we have to un-hide the template arguments to make a copy :(
     switch (referenceGeometry_->getGeometryType()) {
         case ReferenceGeometryType::LINE:
@@ -77,9 +78,6 @@ ElementGeometry::ElementGeometry(const ElementGeometry& other)
                 static_cast<PhysicalGeometry<1>*>(other.physicalGeometry_)
                     ->getNodeCoordinates(),
                 referenceGeometry_);
-            referenceToPhysicalMapping_ = createMappings<1>(
-                other.physicalGeometry_->getNodeIndexes().size(),
-                static_cast<PhysicalGeometry<1>*>(physicalGeometry_));
             break;
         case ReferenceGeometryType::SQUARE:
         case ReferenceGeometryType::TRIANGLE:
@@ -88,9 +86,6 @@ ElementGeometry::ElementGeometry(const ElementGeometry& other)
                 static_cast<PhysicalGeometry<2>*>(other.physicalGeometry_)
                     ->getNodeCoordinates(),
                 referenceGeometry_);
-            referenceToPhysicalMapping_ = createMappings<2>(
-                other.physicalGeometry_->getNodeIndexes().size(),
-                static_cast<PhysicalGeometry<2>*>(physicalGeometry_));
             break;
         case ReferenceGeometryType::TETRAHEDRON:
         case ReferenceGeometryType::CUBE:
@@ -101,9 +96,6 @@ ElementGeometry::ElementGeometry(const ElementGeometry& other)
                 static_cast<PhysicalGeometry<3>*>(other.physicalGeometry_)
                     ->getNodeCoordinates(),
                 referenceGeometry_);
-            referenceToPhysicalMapping_ = createMappings<3>(
-                other.physicalGeometry_->getNodeIndexes().size(),
-                static_cast<PhysicalGeometry<3>*>(physicalGeometry_));
             break;
         case ReferenceGeometryType::HYPERCUBE:
             physicalGeometry_ = createPhysicalGeometry<4>(
@@ -111,9 +103,6 @@ ElementGeometry::ElementGeometry(const ElementGeometry& other)
                 static_cast<PhysicalGeometry<4>*>(other.physicalGeometry_)
                     ->getNodeCoordinates(),
                 referenceGeometry_);
-            referenceToPhysicalMapping_ = createMappings<4>(
-                other.physicalGeometry_->getNodeIndexes().size(),
-                static_cast<PhysicalGeometry<4>*>(physicalGeometry_));
             break;
         case ReferenceGeometryType::POINT:
             logger(ERROR, "-1 dimensional faces are not allowed!");

--- a/kernel/Geometry/ElementGeometry.h
+++ b/kernel/Geometry/ElementGeometry.h
@@ -194,7 +194,8 @@ PointReference<DIM> ElementGeometry::physicalToReference(
 template <std::size_t DIM>
 Jacobian<DIM, DIM> ElementGeometry::calcJacobian(
     const PointReference<DIM>& pointReference) const {
-    return referenceToPhysicalMapping_->calcJacobian(pointReference);
+    return referenceToPhysicalMapping_->castDimension<DIM>().calcJacobian(
+        pointReference);
 }
 
 /// Create the reference element for the given number of nodes. Since this

--- a/kernel/Geometry/ElementGeometry.h
+++ b/kernel/Geometry/ElementGeometry.h
@@ -70,7 +70,7 @@ template <std::size_t DIM>
 class PointReference;
 template <std::size_t DIM>
 class PointPhysical;
-class MappingReferenceToPhysical;
+class MappingReferenceToPhysicalBase;
 class PhysicalGeometryBase;
 class ReferenceGeometry;
 class RefinementGeometry;
@@ -90,8 +90,8 @@ class ElementGeometry {
     virtual ~ElementGeometry();
 
     /// Returns a pointer to the referenceToPhysicalMapping
-    const MappingReferenceToPhysical* getReferenceToPhysicalMap() const;
-    MappingReferenceToPhysical* getReferenceToPhysicalMap();
+    const MappingReferenceToPhysicalBase* getReferenceToPhysicalMap() const;
+    MappingReferenceToPhysicalBase* getReferenceToPhysicalMap();
 
     /// Returns a pointer to the physicalGeometry object.
     const PhysicalGeometryBase* getPhysicalGeometry() const;
@@ -153,7 +153,7 @@ class ElementGeometry {
         const ReferenceGeometry* const geo);
 
     template <std::size_t DIM>
-    static MappingReferenceToPhysical* createMappings(
+    static MappingReferenceToPhysicalBase* createMappings(
         std::size_t size, const PhysicalGeometry<DIM>* const pGeo);
 
    protected:
@@ -166,7 +166,7 @@ class ElementGeometry {
 
     /// The referenceToPhysicalMapping relates the coordinates of the reference
     /// object to the physical object; basically a matrix transformation.
-    MappingReferenceToPhysical* referenceToPhysicalMapping_;
+    MappingReferenceToPhysicalBase* referenceToPhysicalMapping_;
 
     /// The corresponding refinementGeometry object
     RefinementMapping* refinementMap_;
@@ -275,14 +275,14 @@ PhysicalGeometry<DIM>* ElementGeometry::createPhysicalGeometry(
 }
 
 template <std::size_t DIM>
-MappingReferenceToPhysical* ElementGeometry::createMappings(
+MappingReferenceToPhysicalBase* ElementGeometry::createMappings(
     std::size_t size, const PhysicalGeometry<DIM>* const pGeo) {
     logger(ERROR, "DIM may range from 1 to 4, but it seems to be %", DIM);
     return nullptr;
 }
 
 template <>
-inline MappingReferenceToPhysical* ElementGeometry::createMappings(
+inline MappingReferenceToPhysicalBase* ElementGeometry::createMappings(
     std::size_t size, const PhysicalGeometry<1>* const pGeo) {
     logger.assert_debug(pGeo != nullptr, "Invalid physical geometry passed");
     logger.assert_debug(size == 2, "1D can only map to a line");
@@ -291,7 +291,7 @@ inline MappingReferenceToPhysical* ElementGeometry::createMappings(
 }
 
 template <>
-inline MappingReferenceToPhysical* ElementGeometry::createMappings(
+inline MappingReferenceToPhysicalBase* ElementGeometry::createMappings(
     std::size_t size, const PhysicalGeometry<2>* const pGeo) {
     logger.assert_debug(pGeo != nullptr, "Invalid physical geometry passed");
     switch (size) {
@@ -308,7 +308,7 @@ inline MappingReferenceToPhysical* ElementGeometry::createMappings(
 }
 
 template <>
-inline MappingReferenceToPhysical* ElementGeometry::createMappings(
+inline MappingReferenceToPhysicalBase* ElementGeometry::createMappings(
     std::size_t size, const PhysicalGeometry<3>* const pGeo) {
     logger.assert_debug(pGeo != nullptr, "Invalid physical geometry passed");
     switch (size) {
@@ -332,7 +332,7 @@ inline MappingReferenceToPhysical* ElementGeometry::createMappings(
 }
 
 template <>
-inline MappingReferenceToPhysical* ElementGeometry::createMappings(
+inline MappingReferenceToPhysicalBase* ElementGeometry::createMappings(
     std::size_t size, const PhysicalGeometry<4>* const pGeo) {
     logger.assert_debug(pGeo != nullptr, "Invalid physical geometry passed");
     logger.assert_debug(size == 16, "4D can only map to a hypercube");

--- a/kernel/Geometry/ElementGeometry.h
+++ b/kernel/Geometry/ElementGeometry.h
@@ -178,13 +178,15 @@ class ElementGeometry {
 template <std::size_t DIM>
 PointPhysical<DIM> ElementGeometry::referenceToPhysical(
     const PointReference<DIM>& pointReference) const {
-    return referenceToPhysicalMapping_->transform(pointReference);
+    return referenceToPhysicalMapping_->castDimension<DIM>().transform(
+        pointReference);
 }
 
 template <std::size_t DIM>
 PointReference<DIM> ElementGeometry::physicalToReference(
     const PointPhysical<DIM>& pointPhysical) const {
-    return referenceToPhysicalMapping_->inverseTransform(pointPhysical);
+    return referenceToPhysicalMapping_->castDimension<DIM>().inverseTransform(
+        pointPhysical);
 }
 
 /// This method gets a PointReference and returns the corresponding Jacobian of

--- a/kernel/Geometry/Mappings/MappingReferenceToPhysical.h
+++ b/kernel/Geometry/Mappings/MappingReferenceToPhysical.h
@@ -40,6 +40,8 @@
 #define HPGEM_KERNEL_MAPPINGREFERENCETOPHYSICAL_H
 
 #include "Geometry/PhysicalGeometry.h"
+#include "Geometry/PointPhysical.h"
+#include "Geometry/Jacobian.h"
 #include "Logger.h"
 
 #include <vector>
@@ -47,9 +49,6 @@
 namespace hpgem {
 
 namespace Geometry {
-
-template <std::size_t DIM>
-class PointPhysical;
 
 /*! ~OC~
  Second layer abstract base class (derived from Mapping) for mappings

--- a/kernel/Geometry/Mappings/MappingReferenceToPhysical.h
+++ b/kernel/Geometry/Mappings/MappingReferenceToPhysical.h
@@ -39,10 +39,9 @@
 #ifndef HPGEM_KERNEL_MAPPINGREFERENCETOPHYSICAL_H
 #define HPGEM_KERNEL_MAPPINGREFERENCETOPHYSICAL_H
 
-#include "MappingInterface.h"
-#include "Logger.h"
-#include "Geometry/PhysicalGeometryBase.h"
 #include "Geometry/PhysicalGeometry.h"
+#include "Logger.h"
+
 #include <vector>
 
 namespace hpgem {
@@ -73,6 +72,7 @@ class PointPhysical;
  supported so there in no need to template this class
 */
 
+// Forward definition for templating
 template <std::size_t DIM>
 class MappingReferenceToPhysicalDim;
 
@@ -117,7 +117,8 @@ class MappingReferenceToPhysical
     virtual MappingReferenceToPhysical* copy() const = 0;
 
     /**
-     * @return The dimension of the reference and physical points in the mapping.
+     * @return The dimension of the reference and physical points in the
+     * mapping.
      */
     virtual std::size_t getDimension() const = 0;
 };

--- a/kernel/Geometry/Mappings/MappingReferenceToPhysical.h
+++ b/kernel/Geometry/Mappings/MappingReferenceToPhysical.h
@@ -74,26 +74,26 @@ class PointPhysical;
 
 // Forward definition for templating
 template <std::size_t DIM>
-class MappingReferenceToPhysicalDim;
+class MappingReferenceToPhysical;
 
 /**
  * Mapping between the reference and physical geometries of an Element.
  * Specifically this maps the PointReference in the ReferenceGeometry to the
  * corresponding PointPhysical in the PhysicalGeometry.
  */
-class MappingReferenceToPhysical
-    : public AbstractDimensionlessBase<MappingReferenceToPhysical,
-                                       MappingReferenceToPhysicalDim> {
+class MappingReferenceToPhysicalBase
+    : public AbstractDimensionlessBase<MappingReferenceToPhysicalBase,
+                                       MappingReferenceToPhysical> {
 
    public:
-    MappingReferenceToPhysical() = default;
+    MappingReferenceToPhysicalBase() = default;
 
     // Note that the memory of nodes is managed by Mesh, so do not make a deep
     // copy.
-    MappingReferenceToPhysical(const MappingReferenceToPhysical& other) =
+    MappingReferenceToPhysicalBase(const MappingReferenceToPhysicalBase& other) =
         default;
 
-    virtual ~MappingReferenceToPhysical() = default;
+    virtual ~MappingReferenceToPhysicalBase() = default;
 
     /**
      * Recompute the map when the physical nodes have moved.
@@ -114,7 +114,7 @@ class MappingReferenceToPhysical
      * @return A pointer to a copy of the actual mapping instance. The caller is
      * responsible for cleaning it up.
      */
-    virtual MappingReferenceToPhysical* copy() const = 0;
+    virtual MappingReferenceToPhysicalBase* copy() const = 0;
 
     /**
      * @return The dimension of the reference and physical points in the
@@ -124,10 +124,10 @@ class MappingReferenceToPhysical
 };
 
 template <std::size_t DIM>
-class MappingReferenceToPhysicalDim : public MappingReferenceToPhysical {
+class MappingReferenceToPhysical : public MappingReferenceToPhysicalBase {
    public:
-    MappingReferenceToPhysicalDim(const PhysicalGeometry<DIM>* target)
-        : MappingReferenceToPhysical(), geometry_(target) {
+    MappingReferenceToPhysical(const PhysicalGeometry<DIM>* target)
+        : MappingReferenceToPhysicalBase(), geometry_(target) {
         logger.assert_debug(geometry_ != nullptr, "Nullpointer geometry");
     }
 

--- a/kernel/Geometry/Mappings/MappingReferenceToPhysical.h
+++ b/kernel/Geometry/Mappings/MappingReferenceToPhysical.h
@@ -89,8 +89,8 @@ class MappingReferenceToPhysicalBase
 
     // Note that the memory of nodes is managed by Mesh, so do not make a deep
     // copy.
-    MappingReferenceToPhysicalBase(const MappingReferenceToPhysicalBase& other) =
-        default;
+    MappingReferenceToPhysicalBase(
+        const MappingReferenceToPhysicalBase& other) = default;
 
     virtual ~MappingReferenceToPhysicalBase() = default;
 

--- a/kernel/Geometry/Mappings/MappingToPhysHypercubeLinear.cpp
+++ b/kernel/Geometry/Mappings/MappingToPhysHypercubeLinear.cpp
@@ -53,7 +53,7 @@ namespace Geometry {
 // =============================================================================================
 MappingToPhysHypercubeLinear<1>::MappingToPhysHypercubeLinear(
     const PhysicalGeometry<1>* const& physicalGeometry)
-    : MappingReferenceToPhysicalDim<1>(physicalGeometry) {
+    : MappingReferenceToPhysical<1>(physicalGeometry) {
     logger.assert_debug(physicalGeometry != nullptr,
                         "Invalid physical geometry passed");
     mid = slope = 0.0;
@@ -105,7 +105,7 @@ Jacobian<1, 1> MappingToPhysHypercubeLinear<1>::calcJacobian(
 
 MappingToPhysHypercubeLinear<2>::MappingToPhysHypercubeLinear(
     const PhysicalGeometry<2>* const& physicalGeometry)
-    : MappingReferenceToPhysicalDim<2>(physicalGeometry) {
+    : MappingReferenceToPhysical<2>(physicalGeometry) {
     logger.assert_debug(physicalGeometry != nullptr,
                         "Invalid physical geometry passed");
     reinit();
@@ -214,7 +214,7 @@ bool MappingToPhysHypercubeLinear<2>::isValidPoint(
 
 MappingToPhysHypercubeLinear<3>::MappingToPhysHypercubeLinear(
     const PhysicalGeometry<3>* const& physicalGeometry)
-    : MappingReferenceToPhysicalDim<3>(physicalGeometry) {
+    : MappingReferenceToPhysical<3>(physicalGeometry) {
     logger.assert_debug(physicalGeometry != nullptr,
                         "Invalid physical geometry passed");
     reinit();
@@ -320,7 +320,7 @@ bool MappingToPhysHypercubeLinear<3>::isValidPoint(
 
 MappingToPhysHypercubeLinear<4>::MappingToPhysHypercubeLinear(
     const PhysicalGeometry<4>* const& physicalGeometry)
-    : MappingReferenceToPhysicalDim<4>(physicalGeometry) {
+    : MappingReferenceToPhysical<4>(physicalGeometry) {
     logger.assert_debug(physicalGeometry != nullptr,
                         "Invalid physical geometry passed");
     reinit();

--- a/kernel/Geometry/Mappings/MappingToPhysHypercubeLinear.cpp
+++ b/kernel/Geometry/Mappings/MappingToPhysHypercubeLinear.cpp
@@ -53,7 +53,7 @@ namespace Geometry {
 // =============================================================================================
 MappingToPhysHypercubeLinear<1>::MappingToPhysHypercubeLinear(
     const PhysicalGeometry<1>* const& physicalGeometry)
-    : MappingReferenceToPhysical(physicalGeometry) {
+    : MappingReferenceToPhysicalDim<1>(physicalGeometry) {
     logger.assert_debug(physicalGeometry != nullptr,
                         "Invalid physical geometry passed");
     mid = slope = 0.0;
@@ -80,8 +80,8 @@ PointReference<1> MappingToPhysHypercubeLinear<1>::inverseTransform(
 }
 
 void MappingToPhysHypercubeLinear<1>::reinit() {
-    PointPhysical<1> p0 = this->geometry->getLocalNodeCoordinates(0);
-    PointPhysical<1> p1 = this->geometry->getLocalNodeCoordinates(1);
+    PointPhysical<1> p0 = this->geometry_->getLocalNodeCoordinates(0);
+    PointPhysical<1> p1 = this->geometry_->getLocalNodeCoordinates(1);
     mid = 0.5 * (p1[0] + p0[0]);
     slope = 0.5 * (p1[0] - p0[0]);
 }
@@ -105,7 +105,7 @@ Jacobian<1, 1> MappingToPhysHypercubeLinear<1>::calcJacobian(
 
 MappingToPhysHypercubeLinear<2>::MappingToPhysHypercubeLinear(
     const PhysicalGeometry<2>* const& physicalGeometry)
-    : MappingReferenceToPhysical(physicalGeometry) {
+    : MappingReferenceToPhysicalDim<2>(physicalGeometry) {
     logger.assert_debug(physicalGeometry != nullptr,
                         "Invalid physical geometry passed");
     reinit();
@@ -181,10 +181,10 @@ void MappingToPhysHypercubeLinear<2>::reinit() {
     // a2  = 0.25 * (p2 - p0 + p3 - p1);
     // a12 = 0.25 * (p3 - p1 + p0 - p2);
 
-    a0 = geometry->getLocalNodeCoordinates(0);
-    a1 = geometry->getLocalNodeCoordinates(1);
-    a2 = geometry->getLocalNodeCoordinates(2);
-    PointPhysical<2> temp = geometry->getLocalNodeCoordinates(3);
+    a0 = geometry_->getLocalNodeCoordinates(0);
+    a1 = geometry_->getLocalNodeCoordinates(1);
+    a2 = geometry_->getLocalNodeCoordinates(2);
+    PointPhysical<2> temp = geometry_->getLocalNodeCoordinates(3);
     a0 += temp;
     a12 = a1;
     a12 += a2;
@@ -214,7 +214,7 @@ bool MappingToPhysHypercubeLinear<2>::isValidPoint(
 
 MappingToPhysHypercubeLinear<3>::MappingToPhysHypercubeLinear(
     const PhysicalGeometry<3>* const& physicalGeometry)
-    : MappingReferenceToPhysical(physicalGeometry) {
+    : MappingReferenceToPhysicalDim<3>(physicalGeometry) {
     logger.assert_debug(physicalGeometry != nullptr,
                         "Invalid physical geometry passed");
     reinit();
@@ -285,14 +285,14 @@ Jacobian<3, 3> MappingToPhysHypercubeLinear<3>::calcJacobian(
 }
 
 void MappingToPhysHypercubeLinear<3>::reinit() {
-    PointPhysical<3> p0 = geometry->getLocalNodeCoordinates(0);
-    PointPhysical<3> p1 = geometry->getLocalNodeCoordinates(1);
-    PointPhysical<3> p2 = geometry->getLocalNodeCoordinates(2);
-    PointPhysical<3> p3 = geometry->getLocalNodeCoordinates(3);
-    PointPhysical<3> p4 = geometry->getLocalNodeCoordinates(4);
-    PointPhysical<3> p5 = geometry->getLocalNodeCoordinates(5);
-    PointPhysical<3> p6 = geometry->getLocalNodeCoordinates(6);
-    PointPhysical<3> p7 = geometry->getLocalNodeCoordinates(7);
+    PointPhysical<3> p0 = geometry_->getLocalNodeCoordinates(0);
+    PointPhysical<3> p1 = geometry_->getLocalNodeCoordinates(1);
+    PointPhysical<3> p2 = geometry_->getLocalNodeCoordinates(2);
+    PointPhysical<3> p3 = geometry_->getLocalNodeCoordinates(3);
+    PointPhysical<3> p4 = geometry_->getLocalNodeCoordinates(4);
+    PointPhysical<3> p5 = geometry_->getLocalNodeCoordinates(5);
+    PointPhysical<3> p6 = geometry_->getLocalNodeCoordinates(6);
+    PointPhysical<3> p7 = geometry_->getLocalNodeCoordinates(7);
 
     a0 = 0.125 * (p0 + p1 + p2 + p3 + p4 + p5 + p6 + p7);
     a1 = 0.125 * (p1 - p0 + p3 - p2 + p5 - p4 + p7 - p6);
@@ -320,7 +320,7 @@ bool MappingToPhysHypercubeLinear<3>::isValidPoint(
 
 MappingToPhysHypercubeLinear<4>::MappingToPhysHypercubeLinear(
     const PhysicalGeometry<4>* const& physicalGeometry)
-    : MappingReferenceToPhysical(physicalGeometry) {
+    : MappingReferenceToPhysicalDim<4>(physicalGeometry) {
     logger.assert_debug(physicalGeometry != nullptr,
                         "Invalid physical geometry passed");
     reinit();
@@ -386,7 +386,7 @@ Jacobian<4, 4> MappingToPhysHypercubeLinear<4>::calcJacobian(
 void MappingToPhysHypercubeLinear<4>::reinit() {
     std::array<PointPhysical<4>, 16> P;
     for (std::size_t i = 0; i < 16; ++i) {
-        P[i] = geometry->getLocalNodeCoordinates(i);
+        P[i] = geometry_->getLocalNodeCoordinates(i);
     }
 
     abar =

--- a/kernel/Geometry/Mappings/MappingToPhysHypercubeLinear.h
+++ b/kernel/Geometry/Mappings/MappingToPhysHypercubeLinear.h
@@ -62,7 +62,7 @@ class MappingToPhysHypercubeLinear;
 // ~~~==========================================================================
 template <>
 class MappingToPhysHypercubeLinear<1>
-    : public MappingReferenceToPhysicalDim<1> {
+    : public MappingReferenceToPhysical<1> {
 
    public:
     MappingToPhysHypercubeLinear(const PhysicalGeometry<1> *const &);
@@ -86,7 +86,7 @@ class MappingToPhysHypercubeLinear<1>
 // ~~~==========================================================================
 template <>
 class MappingToPhysHypercubeLinear<2>
-    : public MappingReferenceToPhysicalDim<2> {
+    : public MappingReferenceToPhysical<2> {
    public:
     // Constructor.
     MappingToPhysHypercubeLinear(const PhysicalGeometry<2> *const &);
@@ -110,7 +110,7 @@ class MappingToPhysHypercubeLinear<2>
 // ~~~==========================================================================
 template <>
 class MappingToPhysHypercubeLinear<3>
-    : public MappingReferenceToPhysicalDim<3> {
+    : public MappingReferenceToPhysical<3> {
    public:
     // Constructor.
     MappingToPhysHypercubeLinear(const PhysicalGeometry<3> *const &);
@@ -134,7 +134,7 @@ class MappingToPhysHypercubeLinear<3>
 // ~~~==========================================================================
 template <>
 class MappingToPhysHypercubeLinear<4>
-    : public MappingReferenceToPhysicalDim<4> {
+    : public MappingReferenceToPhysical<4> {
    public:
     // Constructor.
     MappingToPhysHypercubeLinear(const PhysicalGeometry<4> *const &);

--- a/kernel/Geometry/Mappings/MappingToPhysHypercubeLinear.h
+++ b/kernel/Geometry/Mappings/MappingToPhysHypercubeLinear.h
@@ -72,7 +72,10 @@ class MappingToPhysHypercubeLinear<1>
     PointReference<1> inverseTransform(const PointPhysical<1> &) const final;
     Jacobian<1, 1> calcJacobian(const PointReference<1> &) const final;
     void reinit() final;
-    std::size_t getTargetDimension() const final { return 1; }
+
+    MappingToPhysHypercubeLinear<1>* copy() const final {
+        return new MappingToPhysHypercubeLinear<1>(*this);
+    }
 
    private:
     bool isValidPoint(const PointReference<1> &) const;
@@ -93,7 +96,10 @@ class MappingToPhysHypercubeLinear<2>
     PointReference<2> inverseTransform(const PointPhysical<2> &) const final;
     Jacobian<2, 2> calcJacobian(const PointReference<2> &) const final;
     void reinit() final;
-    std::size_t getTargetDimension() const final { return 2; }
+
+    MappingToPhysHypercubeLinear<2>* copy() const final {
+        return new MappingToPhysHypercubeLinear<2>(*this);
+    }
 
    private:
     bool isValidPoint(const PointReference<2> &) const;
@@ -114,7 +120,10 @@ class MappingToPhysHypercubeLinear<3>
     PointReference<3> inverseTransform(const PointPhysical<3> &) const final;
     Jacobian<3, 3> calcJacobian(const PointReference<3> &) const final;
     void reinit() final;
-    std::size_t getTargetDimension() const final { return 3; }
+
+    MappingToPhysHypercubeLinear<3>* copy() const final {
+        return new MappingToPhysHypercubeLinear<3>(*this);
+    }
 
    private:
     bool isValidPoint(const PointReference<3> &) const;
@@ -135,7 +144,10 @@ class MappingToPhysHypercubeLinear<4>
     PointReference<4> inverseTransform(const PointPhysical<4> &) const final;
     Jacobian<4, 4> calcJacobian(const PointReference<4> &) const final;
     void reinit() final;
-    std::size_t getTargetDimension() const final { return 4; }
+
+    MappingToPhysHypercubeLinear<4>* copy() const final {
+        return new MappingToPhysHypercubeLinear<4>(*this);
+    }
 
    private:
     bool isValidPoint(const PointReference<4> &) const;

--- a/kernel/Geometry/Mappings/MappingToPhysHypercubeLinear.h
+++ b/kernel/Geometry/Mappings/MappingToPhysHypercubeLinear.h
@@ -61,7 +61,8 @@ class MappingToPhysHypercubeLinear;
 // ~~~ Dimension 1
 // ~~~==========================================================================
 template <>
-class MappingToPhysHypercubeLinear<1> : public MappingReferenceToPhysical {
+class MappingToPhysHypercubeLinear<1>
+    : public MappingReferenceToPhysicalDim<1> {
 
    public:
     MappingToPhysHypercubeLinear(const PhysicalGeometry<1> *const &);
@@ -81,7 +82,8 @@ class MappingToPhysHypercubeLinear<1> : public MappingReferenceToPhysical {
 // ~~~ Dimension 2
 // ~~~==========================================================================
 template <>
-class MappingToPhysHypercubeLinear<2> : public MappingReferenceToPhysical {
+class MappingToPhysHypercubeLinear<2>
+    : public MappingReferenceToPhysicalDim<2> {
    public:
     // Constructor.
     MappingToPhysHypercubeLinear(const PhysicalGeometry<2> *const &);
@@ -101,7 +103,8 @@ class MappingToPhysHypercubeLinear<2> : public MappingReferenceToPhysical {
 // ~~~ Dimension 3
 // ~~~==========================================================================
 template <>
-class MappingToPhysHypercubeLinear<3> : public MappingReferenceToPhysical {
+class MappingToPhysHypercubeLinear<3>
+    : public MappingReferenceToPhysicalDim<3> {
    public:
     // Constructor.
     MappingToPhysHypercubeLinear(const PhysicalGeometry<3> *const &);
@@ -121,7 +124,8 @@ class MappingToPhysHypercubeLinear<3> : public MappingReferenceToPhysical {
 // ~~~ Dimension 4
 // ~~~==========================================================================
 template <>
-class MappingToPhysHypercubeLinear<4> : public MappingReferenceToPhysical {
+class MappingToPhysHypercubeLinear<4>
+    : public MappingReferenceToPhysicalDim<4> {
    public:
     // Constructor.
     MappingToPhysHypercubeLinear(const PhysicalGeometry<4> *const &);

--- a/kernel/Geometry/Mappings/MappingToPhysHypercubeLinear.h
+++ b/kernel/Geometry/Mappings/MappingToPhysHypercubeLinear.h
@@ -61,8 +61,7 @@ class MappingToPhysHypercubeLinear;
 // ~~~ Dimension 1
 // ~~~==========================================================================
 template <>
-class MappingToPhysHypercubeLinear<1>
-    : public MappingReferenceToPhysical<1> {
+class MappingToPhysHypercubeLinear<1> : public MappingReferenceToPhysical<1> {
 
    public:
     MappingToPhysHypercubeLinear(const PhysicalGeometry<1> *const &);
@@ -85,8 +84,7 @@ class MappingToPhysHypercubeLinear<1>
 // ~~~ Dimension 2
 // ~~~==========================================================================
 template <>
-class MappingToPhysHypercubeLinear<2>
-    : public MappingReferenceToPhysical<2> {
+class MappingToPhysHypercubeLinear<2> : public MappingReferenceToPhysical<2> {
    public:
     // Constructor.
     MappingToPhysHypercubeLinear(const PhysicalGeometry<2> *const &);
@@ -109,8 +107,7 @@ class MappingToPhysHypercubeLinear<2>
 // ~~~ Dimension 3
 // ~~~==========================================================================
 template <>
-class MappingToPhysHypercubeLinear<3>
-    : public MappingReferenceToPhysical<3> {
+class MappingToPhysHypercubeLinear<3> : public MappingReferenceToPhysical<3> {
    public:
     // Constructor.
     MappingToPhysHypercubeLinear(const PhysicalGeometry<3> *const &);
@@ -133,8 +130,7 @@ class MappingToPhysHypercubeLinear<3>
 // ~~~ Dimension 4
 // ~~~==========================================================================
 template <>
-class MappingToPhysHypercubeLinear<4>
-    : public MappingReferenceToPhysical<4> {
+class MappingToPhysHypercubeLinear<4> : public MappingReferenceToPhysical<4> {
    public:
     // Constructor.
     MappingToPhysHypercubeLinear(const PhysicalGeometry<4> *const &);

--- a/kernel/Geometry/Mappings/MappingToPhysHypercubeLinear.h
+++ b/kernel/Geometry/Mappings/MappingToPhysHypercubeLinear.h
@@ -73,7 +73,7 @@ class MappingToPhysHypercubeLinear<1>
     Jacobian<1, 1> calcJacobian(const PointReference<1> &) const final;
     void reinit() final;
 
-    MappingToPhysHypercubeLinear<1>* copy() const final {
+    MappingToPhysHypercubeLinear<1> *copy() const final {
         return new MappingToPhysHypercubeLinear<1>(*this);
     }
 
@@ -97,7 +97,7 @@ class MappingToPhysHypercubeLinear<2>
     Jacobian<2, 2> calcJacobian(const PointReference<2> &) const final;
     void reinit() final;
 
-    MappingToPhysHypercubeLinear<2>* copy() const final {
+    MappingToPhysHypercubeLinear<2> *copy() const final {
         return new MappingToPhysHypercubeLinear<2>(*this);
     }
 
@@ -121,7 +121,7 @@ class MappingToPhysHypercubeLinear<3>
     Jacobian<3, 3> calcJacobian(const PointReference<3> &) const final;
     void reinit() final;
 
-    MappingToPhysHypercubeLinear<3>* copy() const final {
+    MappingToPhysHypercubeLinear<3> *copy() const final {
         return new MappingToPhysHypercubeLinear<3>(*this);
     }
 
@@ -145,7 +145,7 @@ class MappingToPhysHypercubeLinear<4>
     Jacobian<4, 4> calcJacobian(const PointReference<4> &) const final;
     void reinit() final;
 
-    MappingToPhysHypercubeLinear<4>* copy() const final {
+    MappingToPhysHypercubeLinear<4> *copy() const final {
         return new MappingToPhysHypercubeLinear<4>(*this);
     }
 

--- a/kernel/Geometry/Mappings/MappingToPhysPyramid.cpp
+++ b/kernel/Geometry/Mappings/MappingToPhysPyramid.cpp
@@ -51,9 +51,7 @@ namespace hpgem {
 namespace Geometry {
 MappingToPhysPyramid::MappingToPhysPyramid(
     const PhysicalGeometry<3>* const physicalGeometry)
-    : MappingReferenceToPhysical(physicalGeometry) {
-    logger.assert_debug(physicalGeometry != nullptr,
-                        "Invalid physical geometry passed");
+    : MappingReferenceToPhysicalDim<3>(physicalGeometry) {
     reinit();
 }
 
@@ -80,7 +78,7 @@ PointPhysical<3> MappingToPhysPyramid::transform(
     pP[0] = pP[1] = pP[2] = 0.0;
 
     for (std::size_t i = 0; i < 5; ++i) {
-        p = geometry->getLocalNodeCoordinates(i);
+        p = geometry_->getLocalNodeCoordinates(i);
         pP += f8[i] * p;
     }
     return pP;
@@ -154,7 +152,7 @@ Jacobian<3, 3> MappingToPhysPyramid::calcJacobian(
     PointPhysical<3> p;
 
     for (std::size_t i = 0; i < 5; ++i) {
-        p = geometry->getLocalNodeCoordinates(i);
+        p = geometry_->getLocalNodeCoordinates(i);
 
         d_dxi0 += df_dxi0[i] * p;
         d_dxi1 += df_dxi1[i] * p;

--- a/kernel/Geometry/Mappings/MappingToPhysPyramid.cpp
+++ b/kernel/Geometry/Mappings/MappingToPhysPyramid.cpp
@@ -51,7 +51,7 @@ namespace hpgem {
 namespace Geometry {
 MappingToPhysPyramid::MappingToPhysPyramid(
     const PhysicalGeometry<3>* const physicalGeometry)
-    : MappingReferenceToPhysicalDim<3>(physicalGeometry) {
+    : MappingReferenceToPhysical<3>(physicalGeometry) {
     reinit();
 }
 

--- a/kernel/Geometry/Mappings/MappingToPhysPyramid.h
+++ b/kernel/Geometry/Mappings/MappingToPhysPyramid.h
@@ -53,7 +53,7 @@ namespace Geometry {
  * This class defines the mappings between reference and physical pyramids.
  */
 
-class MappingToPhysPyramid : public MappingReferenceToPhysical {
+class MappingToPhysPyramid : public MappingReferenceToPhysicalDim<3> {
    public:
     MappingToPhysPyramid(const PhysicalGeometry<3>* const physicalGeometry);
 

--- a/kernel/Geometry/Mappings/MappingToPhysPyramid.h
+++ b/kernel/Geometry/Mappings/MappingToPhysPyramid.h
@@ -53,7 +53,7 @@ namespace Geometry {
  * This class defines the mappings between reference and physical pyramids.
  */
 
-class MappingToPhysPyramid : public MappingReferenceToPhysicalDim<3> {
+class MappingToPhysPyramid : public MappingReferenceToPhysical<3> {
    public:
     MappingToPhysPyramid(const PhysicalGeometry<3>* const physicalGeometry);
 

--- a/kernel/Geometry/Mappings/MappingToPhysPyramid.h
+++ b/kernel/Geometry/Mappings/MappingToPhysPyramid.h
@@ -67,8 +67,11 @@ class MappingToPhysPyramid : public MappingReferenceToPhysicalDim<3> {
 
     void reinit() final;
 
+    MappingToPhysPyramid* copy() const final {
+        return new MappingToPhysPyramid(*this);
+    }
+
     bool isValidPoint(const PointReference<3>&) const;
-    std::size_t getTargetDimension() const final { return 3; }
 };
 }  // namespace Geometry
 }  // namespace hpgem

--- a/kernel/Geometry/Mappings/MappingToPhysSimplexLinear.h
+++ b/kernel/Geometry/Mappings/MappingToPhysSimplexLinear.h
@@ -69,14 +69,17 @@ class MappingToPhysSimplexLinear : public MappingReferenceToPhysicalDim<DIM> {
         reinit();
     }
 
-    MappingToPhysSimplexLinear(const MappingToPhysSimplexLinear<DIM>& other)
-        : MappingReferenceToPhysical(other) {}
+    MappingToPhysSimplexLinear(const MappingToPhysSimplexLinear<DIM>& other) =
+        default;
 
     PointPhysical<DIM> transform(const PointReference<DIM>&) const final;
     PointReference<DIM> inverseTransform(const PointPhysical<DIM>&) const final;
     Jacobian<DIM, DIM> calcJacobian(const PointReference<DIM>&) const final;
     void reinit() final;
-    std::size_t getTargetDimension() const final { return DIM; }
+
+    MappingToPhysSimplexLinear<DIM>* copy() const final {
+        return new MappingToPhysSimplexLinear<DIM>(*this);
+    }
 
    private:
     ///\todo: Implement this function.

--- a/kernel/Geometry/Mappings/MappingToPhysSimplexLinear.h
+++ b/kernel/Geometry/Mappings/MappingToPhysSimplexLinear.h
@@ -62,10 +62,10 @@ namespace Geometry {
  */
 
 template <std::size_t DIM>
-class MappingToPhysSimplexLinear : public MappingReferenceToPhysicalDim<DIM> {
+class MappingToPhysSimplexLinear : public MappingReferenceToPhysical<DIM> {
    public:
     MappingToPhysSimplexLinear(const PhysicalGeometry<DIM>* const& pG)
-        : MappingReferenceToPhysicalDim<DIM>(pG) {
+        : MappingReferenceToPhysical<DIM>(pG) {
         reinit();
     }
 

--- a/kernel/Geometry/Mappings/MappingToPhysSimplexLinear.h
+++ b/kernel/Geometry/Mappings/MappingToPhysSimplexLinear.h
@@ -62,11 +62,10 @@ namespace Geometry {
  */
 
 template <std::size_t DIM>
-class MappingToPhysSimplexLinear : public MappingReferenceToPhysical {
+class MappingToPhysSimplexLinear : public MappingReferenceToPhysicalDim<DIM> {
    public:
     MappingToPhysSimplexLinear(const PhysicalGeometry<DIM>* const& pG)
-        : MappingReferenceToPhysical(pG) {
-        logger.assert_debug(pG != nullptr, "Invalid physical geometry passed");
+        : MappingReferenceToPhysicalDim<DIM>(pG) {
         reinit();
     }
 

--- a/kernel/Geometry/Mappings/MappingToPhysSimplexLinear_Impl.h
+++ b/kernel/Geometry/Mappings/MappingToPhysSimplexLinear_Impl.h
@@ -53,11 +53,11 @@ Geometry::PointPhysical<DIM>
     logger.assert_debug(pointReference.size() == DIM,
                         "Reference point has the wrong dimension");
     Geometry::PointPhysical<DIM> pointPhysical =
-        geometry->getLocalNodeCoordinates(0);
+        this->geometry_->getLocalNodeCoordinates(0);
     for (std::size_t i = 1; i <= DIM; ++i) {
         Geometry::PointPhysical<DIM> next =
-            geometry->getLocalNodeCoordinates(i);
-        next = next - geometry->getLocalNodeCoordinates(0);
+            this->geometry_->getLocalNodeCoordinates(i);
+        next = next - this->geometry_->getLocalNodeCoordinates(0);
         pointPhysical += pointReference[i - 1] * next;
     }
     return pointPhysical;
@@ -68,7 +68,8 @@ Geometry::PointReference<DIM>
     Geometry::MappingToPhysSimplexLinear<DIM>::inverseTransform(
         const PointPhysical<DIM>& pointPhysical) const {
     LinearAlgebra::SmallVector<DIM> offSet =
-        (pointPhysical - geometry->getLocalNodeCoordinates(0)).getCoordinates();
+        (pointPhysical - this->geometry_->getLocalNodeCoordinates(0))
+            .getCoordinates();
     calcJacobian({}).solve(offSet);
     return PointReference<DIM>{offSet};
 }
@@ -82,10 +83,10 @@ Geometry::Jacobian<DIM, DIM>
                         "Reference point has the wrong dimension");
     Jacobian<DIM, DIM> jacobian;
     const Geometry::PointPhysical<DIM>& first =
-        geometry->getLocalNodeCoordinates(0);
+        this->geometry_->getLocalNodeCoordinates(0);
     for (std::size_t i = 0; i < DIM; i++) {
         const PointPhysical<DIM>& point =
-            geometry->getLocalNodeCoordinates(i + 1);
+            this->geometry_->getLocalNodeCoordinates(i + 1);
         for (std::size_t j = 0; j < DIM; j++) {
             jacobian(j, i) = point[j] - first[j];
         }

--- a/kernel/Geometry/Mappings/MappingToPhysTriangularPrism.cpp
+++ b/kernel/Geometry/Mappings/MappingToPhysTriangularPrism.cpp
@@ -51,7 +51,7 @@ namespace hpgem {
 namespace Geometry {
 MappingToPhysTriangularPrism::MappingToPhysTriangularPrism(
     const PhysicalGeometry<3>* const physicalGeometry)
-    : MappingReferenceToPhysical(physicalGeometry) {
+    : MappingReferenceToPhysicalDim<3>(physicalGeometry) {
     logger.assert_debug(physicalGeometry != nullptr,
                         "Invalid physical geometry passed");
     reinit();
@@ -78,7 +78,7 @@ PointPhysical<3> MappingToPhysTriangularPrism::transform(
     PointPhysical<3> p;
 
     for (std::size_t i = 0; i < 6; ++i) {
-        p = geometry->getLocalNodeCoordinates(i);
+        p = geometry_->getLocalNodeCoordinates(i);
         pP += f2[i] * p;
     }
     return pP;
@@ -156,7 +156,7 @@ Jacobian<3, 3> MappingToPhysTriangularPrism::calcJacobian(
     Geometry::PointPhysical<3> p;
 
     for (std::size_t i = 0; i < 6; ++i) {
-        p = geometry->getLocalNodeCoordinates(i);
+        p = geometry_->getLocalNodeCoordinates(i);
 
         d_dxi0 += df_dxi0[i] * p;
         d_dxi1 += df_dxi1[i] * p;

--- a/kernel/Geometry/Mappings/MappingToPhysTriangularPrism.cpp
+++ b/kernel/Geometry/Mappings/MappingToPhysTriangularPrism.cpp
@@ -51,7 +51,7 @@ namespace hpgem {
 namespace Geometry {
 MappingToPhysTriangularPrism::MappingToPhysTriangularPrism(
     const PhysicalGeometry<3>* const physicalGeometry)
-    : MappingReferenceToPhysicalDim<3>(physicalGeometry) {
+    : MappingReferenceToPhysical<3>(physicalGeometry) {
     logger.assert_debug(physicalGeometry != nullptr,
                         "Invalid physical geometry passed");
     reinit();

--- a/kernel/Geometry/Mappings/MappingToPhysTriangularPrism.h
+++ b/kernel/Geometry/Mappings/MappingToPhysTriangularPrism.h
@@ -52,7 +52,7 @@ namespace Geometry {
  *  purpose of individual methods see the documentation of the base classes,
  *  Ref2PhysSpaceMapping and Mapping. */
 
-class MappingToPhysTriangularPrism : public MappingReferenceToPhysical {
+class MappingToPhysTriangularPrism : public MappingReferenceToPhysicalDim<3> {
    public:
     MappingToPhysTriangularPrism(const PhysicalGeometry<3>* const);
 

--- a/kernel/Geometry/Mappings/MappingToPhysTriangularPrism.h
+++ b/kernel/Geometry/Mappings/MappingToPhysTriangularPrism.h
@@ -52,7 +52,7 @@ namespace Geometry {
  *  purpose of individual methods see the documentation of the base classes,
  *  Ref2PhysSpaceMapping and Mapping. */
 
-class MappingToPhysTriangularPrism : public MappingReferenceToPhysicalDim<3> {
+class MappingToPhysTriangularPrism : public MappingReferenceToPhysical<3> {
    public:
     MappingToPhysTriangularPrism(const PhysicalGeometry<3>* const);
 

--- a/kernel/Geometry/Mappings/MappingToPhysTriangularPrism.h
+++ b/kernel/Geometry/Mappings/MappingToPhysTriangularPrism.h
@@ -68,7 +68,10 @@ class MappingToPhysTriangularPrism : public MappingReferenceToPhysicalDim<3> {
     void reinit() final;
 
     bool isValidPoint(const PointReference<3>&) const;
-    std::size_t getTargetDimension() const final { return 3; }
+
+    MappingToPhysTriangularPrism* copy() const final {
+        return new MappingToPhysTriangularPrism(*this);
+    }
 
    private:
     PointPhysical<3> a0, a1, a2, a3, a4, a5;

--- a/tests/unit/Geometry/220ElementGeometry_UnitTest.cpp
+++ b/tests/unit/Geometry/220ElementGeometry_UnitTest.cpp
@@ -96,12 +96,14 @@ TEST_CASE("220ElementGeometry_UnitTest", "[220ElementGeometry_UnitTest]") {
     CHECK((test->getNumberOfNodes() == 2));
 
     for (orig1D[0] = -1.51; orig1D[0] < 1.51; orig1D[0] += 0.1) {
-        compare1D = test->getReferenceToPhysicalMap()->transform((orig1D));
+        const auto& mapping =
+            test->getReferenceToPhysicalMap()->castDimension<1>();
+        compare1D = mapping.transform((orig1D));
         point1D = test->referenceToPhysical((orig1D));
         INFO("referenceToPhysical");
         CHECK((std::abs(point1D[0] - compare1D[0]) < 1e-12));
 
-        jaccompare = test->getReferenceToPhysicalMap()->calcJacobian((orig1D));
+        jaccompare = mapping.calcJacobian((orig1D));
         jac = test->calcJacobian((orig1D));
         INFO("calcJacobian");
         CHECK((std::abs(jac[0] - jaccompare[0]) < 1e-12));
@@ -144,16 +146,17 @@ TEST_CASE("220ElementGeometry_UnitTest", "[220ElementGeometry_UnitTest]") {
     CHECK((test->getNumberOfNodes() == 3));
 
     for (orig2D[0] = -1.51; orig2D[0] < 1.51; orig2D[0] += 0.2) {
+        const auto& mapping =
+            test->getReferenceToPhysicalMap()->castDimension<2>();
         for (orig2D[1] = -1.511; orig2D[1] < 1.51; orig2D[1] += 0.2) {
-            compare2D = test->getReferenceToPhysicalMap()->transform((orig2D));
+            compare2D = mapping.transform((orig2D));
             point2D = test->referenceToPhysical((orig2D));
             INFO("referenceToPhysical");
             CHECK((std::abs(point2D[0] - compare2D[0]) < 1e-12));
             INFO("referenceToPhysical");
             CHECK((std::abs(point2D[1] - compare2D[1]) < 1e-12));
 
-            jaccompare2 =
-                test->getReferenceToPhysicalMap()->calcJacobian((orig2D));
+            jaccompare2 = mapping.calcJacobian((orig2D));
             jac2 = test->calcJacobian((orig2D));
             INFO("calcJacobian");
             CHECK((std::abs(jac2[0] - jaccompare2[0]) < 1e-12));
@@ -184,16 +187,17 @@ TEST_CASE("220ElementGeometry_UnitTest", "[220ElementGeometry_UnitTest]") {
     CHECK((test->getNumberOfNodes() == 4));
 
     for (orig2D[0] = -1.51; orig2D[0] < 1.51; orig2D[0] += 0.2) {
+        const auto& mapping =
+            test->getReferenceToPhysicalMap()->castDimension<2>();
         for (orig2D[1] = -1.511; orig2D[1] < 1.51; orig2D[1] += 0.2) {
-            compare2D = test->getReferenceToPhysicalMap()->transform((orig2D));
+            compare2D = mapping.transform((orig2D));
             point2D = test->referenceToPhysical((orig2D));
             INFO("referenceToPhysical");
             CHECK((std::abs(point2D[0] - compare2D[0]) < 1e-12));
             INFO("referenceToPhysical");
             CHECK((std::abs(point2D[1] - compare2D[1]) < 1e-12));
 
-            jaccompare2 =
-                test->getReferenceToPhysicalMap()->calcJacobian((orig2D));
+            jaccompare2 = mapping.calcJacobian((orig2D));
             jac2 = test->calcJacobian((orig2D));
             INFO("calcJacobian");
             CHECK((std::abs(jac2[0] - jaccompare2[0]) < 1e-12));
@@ -263,8 +267,9 @@ TEST_CASE("220ElementGeometry_UnitTest", "[220ElementGeometry_UnitTest]") {
     for (orig3D[0] = -1.51; orig3D[0] < 1.51; orig3D[0] += 0.3) {
         for (orig3D[1] = -1.511; orig3D[1] < 1.51; orig3D[1] += 0.35) {
             for (orig3D[2] = -1.512; orig3D[2] < 1.51; orig3D[2] += 0.3) {
-                compare3D =
-                    test->getReferenceToPhysicalMap()->transform((orig3D));
+                const auto& mapping =
+                    test->getReferenceToPhysicalMap()->castDimension<3>();
+                compare3D = mapping.transform((orig3D));
                 point3D = test->referenceToPhysical((orig3D));
                 INFO("referenceToPhysical");
                 CHECK((std::abs(point3D[0] - compare3D[0]) < 1e-12));
@@ -273,8 +278,7 @@ TEST_CASE("220ElementGeometry_UnitTest", "[220ElementGeometry_UnitTest]") {
                 INFO("referenceToPhysical");
                 CHECK((std::abs(point3D[2] - compare3D[2]) < 1e-12));
 
-                jaccompare3 =
-                    test->getReferenceToPhysicalMap()->calcJacobian((orig3D));
+                jaccompare3 = mapping.calcJacobian((orig3D));
                 jac3 = test->calcJacobian((orig3D));
                 INFO("calcJacobian");
                 CHECK((std::abs(jac3[0] - jaccompare3[0]) < 1e-12));
@@ -315,10 +319,11 @@ TEST_CASE("220ElementGeometry_UnitTest", "[220ElementGeometry_UnitTest]") {
     CHECK((test->getNumberOfNodes() == 5));
 
     for (orig3D[0] = -1.51; orig3D[0] < 1.51; orig3D[0] += 0.3) {
+        const auto& mapping =
+            test->getReferenceToPhysicalMap()->castDimension<3>();
         for (orig3D[1] = -1.511; orig3D[1] < 1.51; orig3D[1] += 0.35) {
             for (orig3D[2] = -1.512; orig3D[2] < 1.51; orig3D[2] += 0.3) {
-                compare3D =
-                    test->getReferenceToPhysicalMap()->transform((orig3D));
+                compare3D = mapping.transform((orig3D));
                 point3D = test->referenceToPhysical((orig3D));
                 INFO("referenceToPhysical");
                 CHECK((std::abs(point3D[0] - compare3D[0]) < 1e-12));
@@ -327,8 +332,7 @@ TEST_CASE("220ElementGeometry_UnitTest", "[220ElementGeometry_UnitTest]") {
                 INFO("referenceToPhysical");
                 CHECK((std::abs(point3D[2] - compare3D[2]) < 1e-12));
 
-                jaccompare3 =
-                    test->getReferenceToPhysicalMap()->calcJacobian((orig3D));
+                jaccompare3 = mapping.calcJacobian((orig3D));
                 jac3 = test->calcJacobian((orig3D));
                 INFO("calcJacobian");
                 CHECK((std::abs(jac3[0] - jaccompare3[0]) < 1e-12));
@@ -369,10 +373,11 @@ TEST_CASE("220ElementGeometry_UnitTest", "[220ElementGeometry_UnitTest]") {
     CHECK((test->getNumberOfNodes() == 6));
 
     for (orig3D[0] = -1.51; orig3D[0] < 1.51; orig3D[0] += 0.3) {
+        const auto& mapping =
+            test->getReferenceToPhysicalMap()->castDimension<3>();
         for (orig3D[1] = -1.511; orig3D[1] < 1.51; orig3D[1] += 0.35) {
             for (orig3D[2] = -1.512; orig3D[2] < 1.51; orig3D[2] += 0.3) {
-                compare3D =
-                    test->getReferenceToPhysicalMap()->transform((orig3D));
+                compare3D = mapping.transform((orig3D));
                 point3D = test->referenceToPhysical((orig3D));
                 INFO("referenceToPhysical");
                 CHECK((std::abs(point3D[0] - compare3D[0]) < 1e-12));
@@ -381,8 +386,7 @@ TEST_CASE("220ElementGeometry_UnitTest", "[220ElementGeometry_UnitTest]") {
                 INFO("referenceToPhysical");
                 CHECK((std::abs(point3D[2] - compare3D[2]) < 1e-12));
 
-                jaccompare3 =
-                    test->getReferenceToPhysicalMap()->calcJacobian((orig3D));
+                jaccompare3 = mapping.calcJacobian((orig3D));
                 jac3 = test->calcJacobian((orig3D));
                 INFO("calcJacobian");
                 CHECK((std::abs(jac3[0] - jaccompare3[0]) < 1e-12));
@@ -425,10 +429,11 @@ TEST_CASE("220ElementGeometry_UnitTest", "[220ElementGeometry_UnitTest]") {
     CHECK((test->getNumberOfNodes() == 8));
 
     for (orig3D[0] = -1.51; orig3D[0] < 1.51; orig3D[0] += 0.3) {
+        const auto& mapping =
+            test->getReferenceToPhysicalMap()->castDimension<3>();
         for (orig3D[1] = -1.511; orig3D[1] < 1.51; orig3D[1] += 0.35) {
             for (orig3D[2] = -1.512; orig3D[2] < 1.51; orig3D[2] += 0.3) {
-                compare3D =
-                    test->getReferenceToPhysicalMap()->transform((orig3D));
+                compare3D = mapping.transform((orig3D));
                 point3D = test->referenceToPhysical((orig3D));
                 INFO("referenceToPhysical");
                 CHECK((std::abs(point3D[0] - compare3D[0]) < 1e-12));
@@ -437,8 +442,7 @@ TEST_CASE("220ElementGeometry_UnitTest", "[220ElementGeometry_UnitTest]") {
                 INFO("referenceToPhysical");
                 CHECK((std::abs(point3D[2] - compare3D[2]) < 1e-12));
 
-                jaccompare3 =
-                    test->getReferenceToPhysicalMap()->calcJacobian((orig3D));
+                jaccompare3 = mapping.calcJacobian((orig3D));
                 jac3 = test->calcJacobian((orig3D));
                 INFO("calcJacobian");
                 CHECK((std::abs(jac3[0] - jaccompare3[0]) < 1e-12));
@@ -572,11 +576,12 @@ TEST_CASE("220ElementGeometry_UnitTest", "[220ElementGeometry_UnitTest]") {
     CHECK((test->getNumberOfNodes() == 16));
 
     for (orig4D[0] = -1.5189; orig4D[0] < 1.541; orig4D[0] += 0.4) {
+        const auto& mapping =
+            test->getReferenceToPhysicalMap()->castDimension<4>();
         for (orig4D[1] = -1.5189; orig4D[1] < 1.541; orig4D[1] += 0.4) {
             for (orig4D[2] = -1.5189; orig4D[2] < 1.541; orig4D[2] += 0.5) {
                 for (orig4D[3] = -1.5189; orig4D[3] < 1.541; orig4D[3] += 0.5) {
-                    compare4D =
-                        test->getReferenceToPhysicalMap()->transform((orig4D));
+                    compare4D = mapping.transform((orig4D));
                     point4D = test->referenceToPhysical((orig4D));
                     INFO("referenceToPhysical");
                     CHECK((std::abs(point4D[0] - compare4D[0]) < 1e-12));
@@ -587,9 +592,7 @@ TEST_CASE("220ElementGeometry_UnitTest", "[220ElementGeometry_UnitTest]") {
                     INFO("referenceToPhysical");
                     CHECK((std::abs(point4D[3] - compare4D[3]) < 1e-12));
 
-                    jaccompare4 =
-                        test->getReferenceToPhysicalMap()->calcJacobian(
-                            (orig4D));
+                    jaccompare4 = mapping.calcJacobian((orig4D));
                     jac4 = test->calcJacobian((orig4D));
                     INFO("calcJacobian");
                     CHECK((std::abs(jac4[0] - jaccompare4[0]) < 1e-12));

--- a/tests/unit/Geometry/220ElementGeometry_UnitTest.cpp
+++ b/tests/unit/Geometry/220ElementGeometry_UnitTest.cpp
@@ -84,7 +84,7 @@ TEST_CASE("220ElementGeometry_UnitTest", "[220ElementGeometry_UnitTest]") {
 
     Geometry::ElementGeometry* test =
         new Geometry::ElementGeometry(pointIndexes, nodes1D);
-    const Geometry::MappingReferenceToPhysical& refMap1 =
+    const Geometry::MappingReferenceToPhysicalBase& refMap1 =
         *test->getReferenceToPhysicalMap();
     const Geometry::ReferenceGeometry& refGeo1 = *test->getReferenceGeometry();
     INFO("getReferenceToPhysicalMap");
@@ -133,7 +133,7 @@ TEST_CASE("220ElementGeometry_UnitTest", "[220ElementGeometry_UnitTest]") {
     delete test;
     test = new Geometry::ElementGeometry(pointIndexes, nodes2D);
 
-    const Geometry::MappingReferenceToPhysical& refMap2 =
+    const Geometry::MappingReferenceToPhysicalBase& refMap2 =
         *test->getReferenceToPhysicalMap();
     const Geometry::ReferenceGeometry& refGeo2 = *test->getReferenceGeometry();
     INFO("getReferenceToPhysicalMap");
@@ -172,7 +172,7 @@ TEST_CASE("220ElementGeometry_UnitTest", "[220ElementGeometry_UnitTest]") {
     delete test;
     test = new Geometry::ElementGeometry(pointIndexes, nodes2D);
 
-    const Geometry::MappingReferenceToPhysical& refMap3 =
+    const Geometry::MappingReferenceToPhysicalBase& refMap3 =
         *test->getReferenceToPhysicalMap();
     const Geometry::ReferenceGeometry& refGeo3 = *test->getReferenceGeometry();
     INFO("getReferenceToPhysicalMap");
@@ -250,7 +250,7 @@ TEST_CASE("220ElementGeometry_UnitTest", "[220ElementGeometry_UnitTest]") {
     delete test;
     test = new Geometry::ElementGeometry(pointIndexes, nodes3D);
 
-    const Geometry::MappingReferenceToPhysical& refMap4 =
+    const Geometry::MappingReferenceToPhysicalBase& refMap4 =
         *test->getReferenceToPhysicalMap();
     const Geometry::ReferenceGeometry& refGeo4 = *test->getReferenceGeometry();
     INFO("getReferenceToPhysicalMap");
@@ -304,7 +304,7 @@ TEST_CASE("220ElementGeometry_UnitTest", "[220ElementGeometry_UnitTest]") {
     delete test;
     test = new Geometry::ElementGeometry(pointIndexes, nodes3D);
 
-    const Geometry::MappingReferenceToPhysical& refMap5 =
+    const Geometry::MappingReferenceToPhysicalBase& refMap5 =
         *test->getReferenceToPhysicalMap();
     const Geometry::ReferenceGeometry& refGeo5 = *test->getReferenceGeometry();
     INFO("getReferenceToPhysicalMap");
@@ -358,7 +358,7 @@ TEST_CASE("220ElementGeometry_UnitTest", "[220ElementGeometry_UnitTest]") {
     delete test;
     test = new Geometry::ElementGeometry(pointIndexes, nodes3D);
 
-    const Geometry::MappingReferenceToPhysical& refMap6 =
+    const Geometry::MappingReferenceToPhysicalBase& refMap6 =
         *test->getReferenceToPhysicalMap();
     const Geometry::ReferenceGeometry& refGeo6 = *test->getReferenceGeometry();
     INFO("getReferenceToPhysicalMap");
@@ -413,7 +413,7 @@ TEST_CASE("220ElementGeometry_UnitTest", "[220ElementGeometry_UnitTest]") {
     delete test;
     test = new Geometry::ElementGeometry(pointIndexes, nodes3D);
 
-    const Geometry::MappingReferenceToPhysical& refMap7 =
+    const Geometry::MappingReferenceToPhysicalBase& refMap7 =
         *test->getReferenceToPhysicalMap();
     const Geometry::ReferenceGeometry& refGeo7 = *test->getReferenceGeometry();
     INFO("getReferenceToPhysicalMap");
@@ -560,7 +560,7 @@ TEST_CASE("220ElementGeometry_UnitTest", "[220ElementGeometry_UnitTest]") {
     delete test;
     test = new Geometry::ElementGeometry(pointIndexes, nodes4D);
 
-    const Geometry::MappingReferenceToPhysical& refMap8 =
+    const Geometry::MappingReferenceToPhysicalBase& refMap8 =
         *test->getReferenceToPhysicalMap();
     const Geometry::ReferenceGeometry& refGeo8 = *test->getReferenceGeometry();
     INFO("getReferenceToPhysicalMap");

--- a/tests/unit/Geometry/Mappings/010MappingToPhysicalHypercubeLinear_UnitTest.cpp
+++ b/tests/unit/Geometry/Mappings/010MappingToPhysicalHypercubeLinear_UnitTest.cpp
@@ -138,8 +138,8 @@ TEST_CASE("010MappingToPhysicalHypercubeLinear_UnitTest",
         CHECK((std::abs(point1D[0] - compare1D[0]) < 1e-12));
     }
 
-    INFO("getTargetDimension");
-    CHECK((mapping1D.getTargetDimension() == 1));
+    INFO("getDimension");
+    CHECK((mapping1D.getDimension() == 1));
     // dim2
     pointIndexes[1] = 7;
 
@@ -244,8 +244,8 @@ TEST_CASE("010MappingToPhysicalHypercubeLinear_UnitTest",
         CHECK(std::abs(point2D[1] - compare2D[1]) < 1e-12);
     }
 
-    INFO("getTargetDimension");
-    CHECK((mapping2D.getTargetDimension() == 2));
+    INFO("getDimension");
+    CHECK((mapping2D.getDimension() == 2));
     // dim3
     pointIndexes[3] = 18;
 
@@ -391,6 +391,6 @@ TEST_CASE("010MappingToPhysicalHypercubeLinear_UnitTest",
         CHECK(std::abs(point3D[2] - compare3D[2]) < 1e-12);
     }
 
-    INFO("getTargetDimension");
-    CHECK((mapping3D.getTargetDimension() == 3));
+    INFO("getDimension");
+    CHECK((mapping3D.getDimension() == 3));
 }

--- a/tests/unit/Geometry/Mappings/020MappingToPhysicalSimplexLinear_UnitTest.cpp
+++ b/tests/unit/Geometry/Mappings/020MappingToPhysicalSimplexLinear_UnitTest.cpp
@@ -184,8 +184,8 @@ TEST_CASE("020MappingToPhysicalSimplexLinear_UnitTest",
         CHECK(std::abs(point2D[1] - compare2D[1]) < 1e-12);
     }
 
-    INFO("getTargetDimension");
-    CHECK((mapping2D.getTargetDimension() == 2));
+    INFO("getDimension");
+    CHECK((mapping2D.getDimension() == 2));
     // dim3
     pointIndexes[2] = 18;
 
@@ -328,6 +328,6 @@ TEST_CASE("020MappingToPhysicalSimplexLinear_UnitTest",
         CHECK(std::abs(point3D[2] - compare3D[2]) < 1e-12);
     }
 
-    INFO("getTargetDimension");
-    CHECK((mapping3D.getTargetDimension() == 3));
+    INFO("getDimension");
+    CHECK((mapping3D.getDimension() == 3));
 }

--- a/tests/unit/Geometry/Mappings/030MappingToPhysicalTriangularPrism_UnitTest.cpp
+++ b/tests/unit/Geometry/Mappings/030MappingToPhysicalTriangularPrism_UnitTest.cpp
@@ -211,6 +211,6 @@ TEST_CASE("030MappingToPhysicalTriangularPrism_UnitTest",
         CHECK(std::abs(point3D[2] - compare3D[2]) < 1e-12);
     }
 
-    INFO("getTargetDimension");
-    CHECK((mapping3D.getTargetDimension() == 3));
+    INFO("getDimension");
+    CHECK((mapping3D.getDimension() == 3));
 }

--- a/tests/unit/Geometry/Mappings/040MappingToPhysicalPyramid_UnitTest.cpp
+++ b/tests/unit/Geometry/Mappings/040MappingToPhysicalPyramid_UnitTest.cpp
@@ -214,6 +214,6 @@ TEST_CASE("040MappingToPhysicalPyramid_UnitTest",
         CHECK(std::abs(point3D[2] - compare3D[2]) < 1e-12);
     }
 
-    INFO("getTargetDimension");
-    CHECK((mapping3D.getTargetDimension() == 3));
+    INFO("getDimension");
+    CHECK((mapping3D.getDimension() == 3));
 }


### PR DESCRIPTION
This changes the mapping between Reference and Physical space. That is, the transformations used to convert between the elements in the mesh (triangles, tetrahedra, etc.) and their reference counter parts which are used to define the basis functions.

This PR replaces the old interface that was a specialization of `MappingInterface<0>` that had methods for dimensions 1-4. It is replaced by a version that is templated on the dimension argument plus a base class without the dimension argument. This is in my view a much cleaner and flexible way to define these mappings, as it does only have the methods for the right dimension.

Reviewing advice:
 1. Look at #121, this code uses the new class introduced there
 2. Look at `MappingReferenceToPhysical`
 3. The rest is refactoring to match the new mapping interface.