### PR TITLE
Add export for non managed matrices

### DIFF
--- a/kernel/Utilities/GlobalMatrix.cpp
+++ b/kernel/Utilities/GlobalMatrix.cpp
@@ -378,6 +378,10 @@ void GlobalPetscMatrix::printMatInfo(MatInfoType type, std::ostream& stream) {
 }
 
 void GlobalPetscMatrix::writeMatlab(const std::string& fileName) {
+    writeMatlab(A_, fileName);
+}
+
+void GlobalPetscMatrix::writeMatlab(Mat mat, const std::string& fileName) {
     PetscViewer viewer;
     PetscErrorCode err;
 
@@ -385,7 +389,7 @@ void GlobalPetscMatrix::writeMatlab(const std::string& fileName) {
     CHKERRABORT(PETSC_COMM_WORLD, err);
     err = PetscViewerPushFormat(viewer, PETSC_VIEWER_ASCII_MATLAB);
     CHKERRABORT(PETSC_COMM_WORLD, err);
-    err = MatView(A_, viewer);
+    err = MatView(mat, viewer);
     CHKERRABORT(PETSC_COMM_WORLD, err);
     err = PetscViewerDestroy(&viewer);
     CHKERRABORT(PETSC_COMM_WORLD, err);

--- a/kernel/Utilities/GlobalMatrix.h
+++ b/kernel/Utilities/GlobalMatrix.h
@@ -144,6 +144,7 @@ class GlobalPetscMatrix : public GlobalMatrix {
 
     void printMatInfo(MatInfoType type, std::ostream& stream);
     void writeMatlab(const std::string& fileName);
+    static void writeMatlab(Mat mat, const std::string& fileName);
     /// \brief Optional override for the use of face coupling.
     ///
     /// Optionally override the face-coupling between DoFs for the sparsity


### PR DESCRIPTION
I often have to duplicate the code exporting the raw Petsc `Mat` object.  This PR exposes the code that exposes these matrices so that I don't have to keep on duplicating it.