### PR TITLE
Introduce an abstraction over MeshEntities

### DIFF
--- a/kernel/Base/Edge.cpp
+++ b/kernel/Base/Edge.cpp
@@ -111,7 +111,7 @@ bool Edge::isOwnedByCurrentProcessor() const {
     return elements_.size() > 0 && elements_[0]->isOwnedByCurrentProcessor();
 }
 
-Element* Edge::getOwningElement() const {
+const Element* Edge::getOwningElement() const {
 #if HPGEM_ASSERTS
     if (!isOwnedByCurrentProcessor()) {
         // This edge is part of the layer of ghost cells around the owned part

--- a/kernel/Base/Edge.h
+++ b/kernel/Base/Edge.h
@@ -42,6 +42,7 @@
 #include <vector>
 #include <cstdlib>
 
+#include "MeshEntity.h"
 #include "Logger.h"
 #include "TreeEntry.h"
 
@@ -58,7 +59,7 @@ class Element;
  * so they can connect edge-based conforming degrees of freedom to the proper
  * elements. \todo 4D support
  */
-class Edge {
+class Edge : public MeshEntity {
    public:
     explicit Edge(std::size_t ID)
         : numberOfConformingDOFOnTheEdge_(std::vector<std::size_t>(0, 0)),
@@ -174,6 +175,14 @@ class Edge {
     /// The element owning this edge, only valid if the edge is owned by the
     /// current processor
     Element* getOwningElement() const;
+
+    void visitEntity(MeshEntityVisitor<>& visitor) final {
+        visitor.visit(*this);
+    }
+
+    void visitEntity(MeshEntityVisitor<true>& visitor) const final {
+        visitor.visit(*this);
+    }
 
    private:
     std::vector<Element*> elements_;

--- a/kernel/Base/Edge.h
+++ b/kernel/Base/Edge.h
@@ -71,7 +71,7 @@ class Edge : public MeshEntity {
 
     void addElement(Element* element, std::size_t edgeNumber);
 
-    std::size_t getLocalNumberOfBasisFunctions() const {
+    std::size_t getLocalNumberOfBasisFunctions() const final {
         std::size_t number = numberOfConformingDOFOnTheEdge_[0];
         for (std::size_t index : numberOfConformingDOFOnTheEdge_)
             logger.assert_debug(
@@ -80,7 +80,8 @@ class Edge : public MeshEntity {
         return numberOfConformingDOFOnTheEdge_[0];
     }
 
-    std::size_t getLocalNumberOfBasisFunctions(std::size_t unknown) const {
+    std::size_t getLocalNumberOfBasisFunctions(
+        std::size_t unknown) const final {
         // TODO: LC, numberOfConformingDOFOnTheNode_ might be smaller than
         // the number of unknowns (as that is not known here). Thus we might
         // index beyond the number of unknowns.
@@ -88,7 +89,7 @@ class Edge : public MeshEntity {
         return numberOfConformingDOFOnTheEdge_[unknown];
     }
 
-    std::size_t getTotalLocalNumberOfBasisFunctions() const {
+    std::size_t getTotalLocalNumberOfBasisFunctions() const final {
         std::size_t result = 0;
         for (auto nbasis : numberOfConformingDOFOnTheEdge_) result += nbasis;
         return result;
@@ -100,7 +101,7 @@ class Edge : public MeshEntity {
         return getLocalNumberOfBasisFunctions();
     }
 
-    std::size_t getID() const { return ID_; }
+    std::size_t getID() const final { return ID_; }
 
     ///\deprecated Does not conform naming conventions, use getNumberOfElements
     /// instead
@@ -170,11 +171,11 @@ class Edge : public MeshEntity {
         return positionInTheTree_;
     }
 
-    bool isOwnedByCurrentProcessor() const;
+    bool isOwnedByCurrentProcessor() const final;
 
     /// The element owning this edge, only valid if the edge is owned by the
     /// current processor
-    Element* getOwningElement() const;
+    const Element* getOwningElement() const final;
 
     void visitEntity(MeshEntityVisitor<>& visitor) final {
         visitor.visit(*this);

--- a/kernel/Base/Element.cpp
+++ b/kernel/Base/Element.cpp
@@ -137,10 +137,6 @@ void Element::setVertexBasisFunctionSet(std::size_t position,
     setNumberOfBasisFunctions(numberOfBasisFunctions, unknown);
 }
 
-std::size_t Element::getID() const { return id_; }
-
-std::size_t Element::getID() { return id_; }
-
 void Element::setQuadratureRulesWithOrder(std::size_t quadrROrder) {
     bool changed = false;
     if (quadratureRule_ == nullptr) {

--- a/kernel/Base/Element.h
+++ b/kernel/Base/Element.h
@@ -56,6 +56,8 @@
 #include <memory>
 #include <Integration/QuadratureRules/GaussQuadratureRule.h>
 #include <Base/ElementBasisFunctions.h>
+#include "MeshEntity.h"
+
 namespace hpgem {
 
 namespace FE {
@@ -74,7 +76,9 @@ class PhysicalElement;
 
 // class is final as a reminder that the virtual default destructor should be
 // added once something inherits from this class
-class Element final : public Geometry::ElementGeometry, public ElementData {
+class Element final : public Geometry::ElementGeometry,
+                      public ElementData,
+                      public MeshEntity {
    public:
     using SolutionVector = LinearAlgebra::MiddleSizeVector;
     using CollectionOfBasisFunctionSets =
@@ -527,6 +531,14 @@ class Element final : public Geometry::ElementGeometry, public ElementData {
     void setOwnedByCurrentProcessor(std::size_t owner, bool owned);
     bool isOwnedByCurrentProcessor() const;
     std::size_t getOwner() const;
+
+    void visitEntity(MeshEntityVisitor<>& visitor) final {
+        visitor.visit(*this);
+    }
+
+    void visitEntity(MeshEntityVisitor<true>& visitor) const final {
+        visitor.visit(*this);
+    }
 
     /// Output operator.
     friend std::ostream& operator<<(std::ostream& os, const Element& element);

--- a/kernel/Base/Element.h
+++ b/kernel/Base/Element.h
@@ -98,9 +98,7 @@ class Element final : public Geometry::ElementGeometry,
 
     Element* copyWithoutFacesEdgesNodes();
 
-    std::size_t getID() const;
-
-    std::size_t getID();
+    std::size_t getID() const final { return id_; }
 
     void setQuadratureRulesWithOrder(std::size_t quadrROrder);
 
@@ -380,15 +378,16 @@ class Element final : public Geometry::ElementGeometry,
     /// element only. This always includes functions with compact support on the
     /// interior of the element and DG basis function, but never include
     /// conforming basis functions that are nonzero on a face, edge or node
-    std::size_t getLocalNumberOfBasisFunctions() const {
+    std::size_t getLocalNumberOfBasisFunctions() const final {
         return basisFunctions_.getNumberOfLocalBasisFunctions();
     }
 
-    std::size_t getLocalNumberOfBasisFunctions(std::size_t unknown) const {
+    std::size_t getLocalNumberOfBasisFunctions(
+        std::size_t unknown) const final {
         return basisFunctions_.getNumberOfLocalBasisFunctions(unknown);
     }
 
-    std::size_t getTotalLocalNumberOfBasisFunctions() const {
+    std::size_t getTotalLocalNumberOfBasisFunctions() const final {
         return basisFunctions_.getTotalLocalNumberOfBasisFunctions();
     }
 
@@ -529,8 +528,10 @@ class Element final : public Geometry::ElementGeometry,
     /// \param owned Whether this element is owned or not by the current
     /// processor.
     void setOwnedByCurrentProcessor(std::size_t owner, bool owned);
-    bool isOwnedByCurrentProcessor() const;
+    bool isOwnedByCurrentProcessor() const final;
     std::size_t getOwner() const;
+
+    const Element* getOwningElement() const final { return this; }
 
     void visitEntity(MeshEntityVisitor<>& visitor) final {
         visitor.visit(*this);

--- a/kernel/Base/Face.cpp
+++ b/kernel/Base/Face.cpp
@@ -381,7 +381,7 @@ bool Face::determineIsPeriodicBoundaryFace() const {
     return globalLeftNodes != globalRightNodes;
 }
 
-Element* Face::getOwningElement() const {
+const Element* Face::getOwningElement() const {
 #if HPGEM_ASSERTS
     bool safe = false;
     // If we own it, then we definitely know the owning element

--- a/kernel/Base/Face.h
+++ b/kernel/Base/Face.h
@@ -44,6 +44,7 @@
 #include "Base/FaceMatrix.h"
 #include "Geometry/FaceGeometry.h"
 #include "Base/Element.h"
+#include "MeshEntity.h"
 #include "L2Norm.h"
 #include "TreeEntry.h"
 
@@ -61,7 +62,9 @@ struct FaceCacheData;
 /// FaceGeometry holds all FaceReference related data and appropriate mappings
 // class is final as a reminder that the virtual default destructor should be
 // added once something inherits from this class
-class Face final : public Geometry::FaceGeometry, public FaceData {
+class Face final : public Geometry::FaceGeometry,
+                   public FaceData,
+                   public MeshEntity {
    public:
     using FaceQuadratureRule = QuadratureRules::GaussQuadratureRule;
 
@@ -362,6 +365,14 @@ class Face final : public Geometry::FaceGeometry, public FaceData {
     /// The element owning this face, only valid if the face is owned by the
     /// current processor
     Element* getOwningElement() const;
+
+    void visitEntity(MeshEntityVisitor<>& visitor) final {
+        visitor.visit(*this);
+    }
+
+    void visitEntity(MeshEntityVisitor<true>& visitor) const final {
+        visitor.visit(*this);
+    }
 
    private:
     Element* elementLeft_;

--- a/kernel/Base/Face.h
+++ b/kernel/Base/Face.h
@@ -264,7 +264,7 @@ class Face final : public Geometry::FaceGeometry,
     std::size_t getNumberOfBasisFunctions() const;
     std::size_t getNumberOfBasisFunctions(std::size_t unknown) const;
 
-    std::size_t getLocalNumberOfBasisFunctions() const {
+    std::size_t getLocalNumberOfBasisFunctions() const final {
         std::size_t number = numberOfConformingDOFOnTheFace_[0];
         for (std::size_t index : numberOfConformingDOFOnTheFace_)
             logger.assert_debug(
@@ -273,14 +273,15 @@ class Face final : public Geometry::FaceGeometry,
         return numberOfConformingDOFOnTheFace_[0];
     }
 
-    std::size_t getLocalNumberOfBasisFunctions(std::size_t unknown) const {
+    std::size_t getLocalNumberOfBasisFunctions(
+        std::size_t unknown) const final {
         logger.assert_debug(unknown < numberOfConformingDOFOnTheFace_.size(),
                             "Asking for unknown % but there are only %",
                             unknown, numberOfConformingDOFOnTheFace_.size());
         return numberOfConformingDOFOnTheFace_[unknown];
     }
 
-    std::size_t getTotalLocalNumberOfBasisFunctions() const {
+    std::size_t getTotalLocalNumberOfBasisFunctions() const final {
         std::size_t result = 0;
         for (auto nbasis : numberOfConformingDOFOnTheFace_) result += nbasis;
         return result;
@@ -319,7 +320,7 @@ class Face final : public Geometry::FaceGeometry,
         setLocalNumberOfBasisFunctions(number);
     }
 
-    std::size_t getID() const { return faceID_; }
+    std::size_t getID() const final { return faceID_; }
 
     /// Specify a time integration vector id, return a vector containing the
     /// data for that time integration vector.
@@ -357,14 +358,14 @@ class Face final : public Geometry::FaceGeometry,
         return positionInTheTree_;
     }
 
-    bool isOwnedByCurrentProcessor() const {
+    bool isOwnedByCurrentProcessor() const final {
         return elementLeft_ != nullptr &&
                elementLeft_->isOwnedByCurrentProcessor();
     }
 
     /// The element owning this face, only valid if the face is owned by the
     /// current processor
-    Element* getOwningElement() const;
+    const Element* getOwningElement() const final;
 
     void visitEntity(MeshEntityVisitor<>& visitor) final {
         visitor.visit(*this);

--- a/kernel/Base/MeshEntity.h
+++ b/kernel/Base/MeshEntity.h
@@ -69,6 +69,8 @@ class MeshEntityVisitor {
     virtual void visit(Constified<Base::Node>& node) = 0;
 };
 
+using ConstMeshEntityVisitor = MeshEntityVisitor<true>;
+
 /**
  * Entity of the Mesh, that is an Element, Face, Edge or Node.
  */

--- a/kernel/Base/MeshEntity.h
+++ b/kernel/Base/MeshEntity.h
@@ -1,0 +1,84 @@
+/*
+ This file forms part of hpGEM. This package has been developed over a number of
+ years by various people at the University of Twente and a full list of
+ contributors can be found at http://hpgem.org/about-the-code/team
+
+ This code is distributed using BSD 3-Clause License. A copy of which can found
+ below.
+
+
+ Copyright (c) 2021, University of Twente
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation
+ and/or other materials provided with the distribution.
+
+ 3. Neither the name of the copyright holder nor the names of its contributors
+ may be used to endorse or promote products derived from this software without
+ specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef HPGEM_MESHENTITY_H
+#define HPGEM_MESHENTITY_H
+
+#include "functional"
+#include <type_traits>
+
+namespace hpgem {
+namespace Base {
+
+// Predeclaration to prevent circular dependency issues
+class Edge;
+class Element;
+class Face;
+class Node;
+
+/**
+ * Visitor for the MeshEntity
+ * @tparam constify Whether the MeshEntities are const or not
+ */
+template <bool constify = false>
+class MeshEntityVisitor {
+   public:
+    /// Helper to add const
+    template <typename T>
+    using Constified =
+        typename std::conditional<constify, typename std::add_const<T>::type,
+                                  T>::type;
+
+    virtual void visit(Constified<Base::Element>& element) = 0;
+    virtual void visit(Constified<Base::Edge>& edge) = 0;
+    virtual void visit(Constified<Base::Face>& face) = 0;
+    virtual void visit(Constified<Base::Node>& node) = 0;
+};
+
+/**
+ * Entity of the Mesh, that is an Element, Face, Edge or Node.
+ */
+class MeshEntity {
+   public:
+    virtual void visitEntity(MeshEntityVisitor<>& vistor) = 0;
+    virtual void visitEntity(MeshEntityVisitor<true>& vistor) const = 0;
+}
+
+}  // namespace Base
+}  // namespace hpgem
+
+#endif  // HPGEM_MESHENTITY_H

--- a/kernel/Base/MeshEntity.h
+++ b/kernel/Base/MeshEntity.h
@@ -76,7 +76,52 @@ class MeshEntity {
    public:
     virtual void visitEntity(MeshEntityVisitor<>& vistor) = 0;
     virtual void visitEntity(MeshEntityVisitor<true>& vistor) const = 0;
-}
+
+    /**
+     * @return The identifier for this MeshEntity
+     */
+    virtual std::size_t getID() const = 0;
+    /**
+     * In a distributed (MPI) problem each mesh entity has a single owning
+     * process.
+     * @return Whether the current process owns the MeshEntity.
+     */
+    virtual bool isOwnedByCurrentProcessor() const = 0;
+    /**
+     * Each MeshEntity is associated with a single element. In a distributed
+     * setting this information is not always available due to the finite size
+     * of the ghost layer. In such a setting three guarantees are given:
+     * 1. If the owning element can not be determined the function will error.
+     * 2. An owning element is always available if this MeshEntity is adjacent
+     *    to an element that is owned by the current process.
+     *
+     * @return The owning element
+     */
+    virtual const Base::Element* getOwningElement() const = 0;
+
+    /**
+     * The number of basis functions per unknown that are associated with this
+     * MeshEntity.
+     *
+     * Legacy behaviour: With multiple unknowns this will crash if the value is
+     * different for the differnt unknowns.
+     * @return
+     */
+    virtual std::size_t getLocalNumberOfBasisFunctions() const = 0;
+    /**
+     * The number of basis functions for a specific unknown that are associated
+     * with this MeshEntity.
+     * @param unknown The unknown to ask the number of basis functions of.
+     * @return The number of basis functions
+     */
+    virtual std::size_t getLocalNumberOfBasisFunctions(
+        std::size_t unknown) const = 0;
+    /**
+     * @return The number of basis functions for all unknowns that are
+     * associated with this MeshEntity.
+     */
+    virtual std::size_t getTotalLocalNumberOfBasisFunctions() const = 0;
+};
 
 }  // namespace Base
 }  // namespace hpgem

--- a/kernel/Base/MeshEntity.h
+++ b/kernel/Base/MeshEntity.h
@@ -57,6 +57,8 @@ class Node;
 template <bool constify = false>
 class MeshEntityVisitor {
    public:
+    
+    virtual ~MeshEntityVisitor() = default;
     /// Helper to add const
     template <typename T>
     using Constified =
@@ -75,6 +77,10 @@ using ConstMeshEntityVisitor = MeshEntityVisitor<true>;
  * Entity of the Mesh, that is an Element, Face, Edge or Node.
  */
 class MeshEntity {
+   protected:
+    // Deletion of MeshEntities should be governed by the actual instances.
+    ~MeshEntity() = default;
+
    public:
     virtual void visitEntity(MeshEntityVisitor<>& vistor) = 0;
     virtual void visitEntity(MeshEntityVisitor<true>& vistor) const = 0;

--- a/kernel/Base/Node.cpp
+++ b/kernel/Base/Node.cpp
@@ -137,7 +137,7 @@ bool Base::Node::isOwnedByCurrentProcessor() const {
     return elements_.size() > 0 && elements_[0]->isOwnedByCurrentProcessor();
 }
 
-Base::Element *Base::Node::getOwningElement() const {
+const Base::Element *Base::Node::getOwningElement() const {
 #if HPGEM_ASSERTS
     if (!isOwnedByCurrentProcessor()) {
         // The node is part of the boundary layer of ghost elements. On the

--- a/kernel/Base/Node.h
+++ b/kernel/Base/Node.h
@@ -82,7 +82,7 @@ class Node : public MeshEntity {
         return getLocalNumberOfBasisFunctions();
     }
 
-    std::size_t getLocalNumberOfBasisFunctions() const {
+    std::size_t getLocalNumberOfBasisFunctions() const final {
         std::size_t number = numberOfConformingDOFOnTheNode_[0];
         for (std::size_t index : numberOfConformingDOFOnTheNode_)
             logger.assert_debug(
@@ -91,20 +91,21 @@ class Node : public MeshEntity {
         return numberOfConformingDOFOnTheNode_[0];
     }
 
-    std::size_t getLocalNumberOfBasisFunctions(std::size_t unknown) const {
+    std::size_t getLocalNumberOfBasisFunctions(
+        std::size_t unknown) const final {
         logger.assert_debug(unknown < numberOfConformingDOFOnTheNode_.size(),
                             "Asking for unknown % but there are only %",
                             unknown, numberOfConformingDOFOnTheNode_.size());
         return numberOfConformingDOFOnTheNode_[unknown];
     }
 
-    std::size_t getTotalLocalNumberOfBasisFunctions() const {
+    std::size_t getTotalLocalNumberOfBasisFunctions() const final {
         std::size_t result = 0;
         for (auto nbasis : numberOfConformingDOFOnTheNode_) result += nbasis;
         return result;
     }
 
-    std::size_t getID() const { return ID_; }
+    std::size_t getID() const final { return ID_; }
 
     ///\deprecated Does not conform naming conventions, use getNumberOfElements
     /// instead
@@ -156,11 +157,11 @@ class Node : public MeshEntity {
         setLocalNumberOfBasisFunctions(number);
     }
 
-    bool isOwnedByCurrentProcessor() const;
+    bool isOwnedByCurrentProcessor() const final;
 
     /// The element owning this node, only valid if the node is owned by the
     /// current processor
-    Element *getOwningElement() const;
+    const Element *getOwningElement() const final;
 
     void visitEntity(MeshEntityVisitor<> &visitor) final {
         visitor.visit(*this);

--- a/kernel/Base/Node.h
+++ b/kernel/Base/Node.h
@@ -43,6 +43,7 @@
 #include <vector>
 
 #include "Logger.h"
+#include "MeshEntity.h"
 
 namespace hpgem {
 
@@ -60,7 +61,7 @@ class Face;
 /// is not uniquely defined and its only identifying feature is the set of
 /// elements connected to it. Elements store a PointPhysical for each node
 /// independently from this class that can be used for geometric operations.
-class Node {
+class Node : public MeshEntity {
    public:
     explicit Node(std::size_t ID)
         : elements_(),
@@ -160,6 +161,14 @@ class Node {
     /// The element owning this node, only valid if the node is owned by the
     /// current processor
     Element *getOwningElement() const;
+
+    void visitEntity(MeshEntityVisitor<> &visitor) final {
+        visitor.visit(*this);
+    }
+
+    void visitEntity(MeshEntityVisitor<true> &visitor) const final {
+        visitor.visit(*this);
+    }
 
    private:
     // provide information to map back to a unique corner of the element

--- a/tests/self/PETSc/005GlobalIndexing_SelfTest.cpp
+++ b/tests/self/PETSc/005GlobalIndexing_SelfTest.cpp
@@ -143,8 +143,9 @@ void checkIndex(Base::MeshManipulator<DIM>& mesh,
     }
 
     // Check that all indices are used.
-    for (const bool b : indexStore.usedIndices) {
-        logger.assert_always(b, "Unused index");
+    for (std::size_t i = 0; i < indexStore.usedIndices.size(); ++i) {
+        logger.assert_always(indexStore.usedIndices[i], "Unused index %/%", i,
+                             indexStore.usedIndices.size());
     }
     // Ensure no resize
     logger.assert_always(


### PR DESCRIPTION
For several processes in hpgem we need to handle all parts of the Mesh (Element, Face, Edge and Node) in an (almost) identical fashion. The current implementations do this by repeating the code for each part, which is both error prone and ugly. This PR tries to alleviate these code smells.

Specifically this PR:
 1. Introduces a pure virtual base class `MeshEntity`, that is the parent of each if the four parts of the Mesh
 2. Introduces a simple visitor to allow differentiating behavior between the different MeshEntities.
 3. Rewrites several parts of `GlobalIndexing` as a proof of concept that it works and the possible effect on code quality.

Some attempts have been made to ensure that the compiler can (theoretically) devirtualize calls to MeshEntities. This is done by:
 1. Marking all the implementation of the functions of `MeshEntity` in the parts as final
 2. Exposing methods that accept a MeshEntity to allow inlining, thereby allowing further differentiation based on the actual MeshEntity type.

First review request: What do you think about the idea/implementation? Any suggestions on whether to continue with this idea?

Natural reviewing order is to start with `MeshEntity` and proceed to either the parts themselves (rather straight forward) or the usage in `GlobalIndexing`.
