### PR TITLE
Reset basis function count

### DIFF
--- a/applications/DG-Wave_linear/main.cpp
+++ b/applications/DG-Wave_linear/main.cpp
@@ -73,14 +73,7 @@ class DGWave : public Base::HpgemAPIBase<DIM>,
     bool initialise() {
         addMesh("mesh.hpgem", 1, 1, 1, 1);
         setNumberOfTimeIntegrationVectorsGlobally(1);
-        meshes_[0]->setDefaultBasisFunctionSet(
-            FE::createInteriorBasisFunctionSet2DH1Square(p_));
-        std::vector<const FE::BasisFunctionSet*> bFsets;
-        bFsets = FE::createVertexBasisFunctionSet2DH1Square(p_);
-        meshes_[0]->addVertexBasisFunctionSet(bFsets);
-        std::vector<const FE::OrientedBasisFunctionSet*> oBFsets;
-        oBFsets = FE::createFaceBasisFunctionSet2DH1Square(p_);
-        meshes_[0]->addFaceBasisFunctionSet(oBFsets);
+        meshes_[0]->useDefaultConformingBasisFunctions(p_);
         return true;
     }
 

--- a/kernel/Base/Element.h
+++ b/kernel/Base/Element.h
@@ -103,13 +103,19 @@ class Element final : public Geometry::ElementGeometry, public ElementData {
     void setGaussQuadratureRule(
         QuadratureRules::GaussQuadratureRule* const quadR);
 
-    void setDefaultBasisFunctionSet(std::size_t position) {
-        // Clear all unknowns so that no old data is left from previous basis
-        // function configurations.
+    void clearBasisFunctions() {
         for (std::size_t unknown = 0; unknown < getNumberOfUnknowns();
              ++unknown) {
             basisFunctions_.clearBasisFunctionPosition(unknown);
         }
+        setNumberOfBasisFunctions(0);
+    }
+
+    void setDefaultBasisFunctionSet(std::size_t position) {
+        // Clear all unknowns so that no old data is left from previous basis
+        // function configurations.
+        clearBasisFunctions();
+        // Then assign new default basis function size
         for (std::size_t unknown = 0; unknown < getNumberOfUnknowns();
              ++unknown) {
             setDefaultBasisFunctionSet(position, unknown);

--- a/kernel/Base/MeshManipulator.h
+++ b/kernel/Base/MeshManipulator.h
@@ -108,6 +108,8 @@ class MeshManipulator : public MeshManipulatorBase {
 
     ~MeshManipulator() override;
 
+    void clearBasisFunctionAssignment();
+
     /// creates some cheap, easy to construct basis function set (monomials) to
     /// use as a placeholder Note that they usually result in very badly
     /// conditioned matrices.
@@ -349,14 +351,6 @@ class MeshManipulator : public MeshManipulatorBase {
     }
     // ************************************************************************
 
-    //! Changes the default set of basisFunctions for this mesh and all of its
-    //! elements. Ignores any conforming basisFunctionset that may be linked to
-    //! faces/edges/...
-    /// Using this to set the hpGEM provided conforming or DG basis functions is
-    /// deprecated: The routines useDefaultDGBasisFunctionSet and
-    /// useDefaultConformingBasisFunctionSet can do this more flexibly and also
-    /// support mixed meshes
-    void setDefaultBasisFunctionSet(FE::BasisFunctionSet* bFSet);
 
     //! Adds vertex based degrees of freedom to the set of basisfunctions for
     //! this mesh and all of its vertices. This routine will assume that the

--- a/kernel/Base/MeshManipulator.h
+++ b/kernel/Base/MeshManipulator.h
@@ -351,7 +351,6 @@ class MeshManipulator : public MeshManipulatorBase {
     }
     // ************************************************************************
 
-
     //! Adds vertex based degrees of freedom to the set of basisfunctions for
     //! this mesh and all of its vertices. This routine will assume that the
     //! first basisfunctionset connects to the first vertex (local numbering)

--- a/kernel/Base/MeshManipulator_Impl.h
+++ b/kernel/Base/MeshManipulator_Impl.h
@@ -98,6 +98,27 @@ class EnumHash {
 };
 namespace hpgem {
 namespace Base {
+
+template<std::size_t DIM>
+void MeshManipulator<DIM>::clearBasisFunctionAssignment() {
+    collBasisFSet_.clear();
+    for(Base::Element* element : getElementsList(IteratorType::GLOBAL)) {
+        element->clearBasisFunctions();
+    }
+
+    for(Base::Face* face : getFacesList(IteratorType::GLOBAL)) {
+        face->setLocalNumberOfBasisFunctions(0);
+    }
+    for(Base::Edge* edge : getEdgesList(IteratorType::GLOBAL)) {
+        edge->setLocalNumberOfBasisFunctions(0);
+    }
+    if (dimension_ > 1) {
+        for (Base::Node *node : getNodesList(IteratorType::GLOBAL)) {
+            node->setLocalNumberOfBasisFunctions(0);
+        }
+    }
+}
+
 template <std::size_t DIM>
 void MeshManipulator<DIM>::useMonomialBasisFunctions(std::size_t order) {
     FE::BasisFunctionSet *bFset1 = new FE::BasisFunctionSet(order);
@@ -118,6 +139,7 @@ void MeshManipulator<DIM>::useMonomialBasisFunctions(std::size_t order) {
         default:
             logger(ERROR, "No basisfunctions exist in this dimension");
     }
+    clearBasisFunctionAssignment();
     collBasisFSet_.resize(1);
     collBasisFSet_[0] = std::shared_ptr<const FE::BasisFunctionSet>(bFset1);
     // Register them all for usage
@@ -131,7 +153,7 @@ void MeshManipulator<DIM>::useMonomialBasisFunctions(std::size_t order) {
 
 template <std::size_t DIM>
 void MeshManipulator<DIM>::useDefaultDGBasisFunctions(std::size_t order) {
-    collBasisFSet_.clear();
+    clearBasisFunctionAssignment();
     std::unordered_map<Geometry::ReferenceGeometryType, std::size_t,
                        EnumHash<Geometry::ReferenceGeometryType>>
         shapeToIndex;
@@ -301,7 +323,7 @@ void MeshManipulator<DIM>::useDefaultDGBasisFunctions(std::size_t order,
 
 template <std::size_t DIM>
 void MeshManipulator<DIM>::useNedelecDGBasisFunctions(std::size_t order) {
-    collBasisFSet_.clear();
+    clearBasisFunctionAssignment();
     std::unordered_map<Geometry::ReferenceGeometryType, std::size_t,
                        EnumHash<Geometry::ReferenceGeometryType>>
         shapeToIndex;
@@ -338,7 +360,7 @@ void MeshManipulator<DIM>::useNedelecDGBasisFunctions(std::size_t order) {
 template <std::size_t DIM>
 void MeshManipulator<DIM>::useAinsworthCoyleDGBasisFunctions(
     std::size_t order) {
-    collBasisFSet_.clear();
+    clearBasisFunctionAssignment();
     std::unordered_map<Geometry::ReferenceGeometryType, std::size_t,
                        EnumHash<Geometry::ReferenceGeometryType>>
         shapeToIndex;
@@ -373,7 +395,7 @@ void MeshManipulator<DIM>::useDefaultConformingBasisFunctions(
                         "Basis function may not have an empty union of "
                         "supporting elements. Use a DG basis function on a "
                         "single element non-periodic mesh instead");
-    collBasisFSet_.clear();
+    clearBasisFunctionAssignment();
     std::unordered_map<Geometry::ReferenceGeometryType, std::size_t,
                        EnumHash<Geometry::ReferenceGeometryType>>
         shapeToElementIndex;
@@ -1010,29 +1032,6 @@ MeshManipulator<DIM>::MeshManipulator(const MeshManipulator &other)
 template <std::size_t DIM>
 MeshManipulator<DIM>::~MeshManipulator() {
     delete meshMover_;
-}
-
-template <std::size_t DIM>
-void MeshManipulator<DIM>::setDefaultBasisFunctionSet(
-    FE::BasisFunctionSet *bFSet) {
-    logger.assert_debug(bFSet != nullptr, "Invalid basis function set passed");
-    if (collBasisFSet_.size() == 0) collBasisFSet_.resize(1);
-    collBasisFSet_[0] = std::shared_ptr<const FE::BasisFunctionSet>(bFSet);
-    const_cast<ConfigurationData *>(configData_)->numberOfBasisFunctions_ =
-        bFSet->size();
-    for (Base::Face *face : getFacesList(IteratorType::GLOBAL)) {
-        face->setLocalNumberOfBasisFunctions(0);
-    }
-    for (Base::Edge *edge : getEdgesList(IteratorType::GLOBAL)) {
-        edge->setLocalNumberOfBasisFunctions(0);
-    }
-    for (Base::Node *node : getNodesList(IteratorType::GLOBAL)) {
-        node->setLocalNumberOfBasisFunctions(0);
-    }
-    for (ElementIterator it = elementColBegin(IteratorType::GLOBAL);
-         it != elementColEnd(IteratorType::GLOBAL); ++it) {
-        (*it)->setDefaultBasisFunctionSet(0);
-    }
 }
 
 template <std::size_t DIM>

--- a/kernel/Base/MeshManipulator_Impl.h
+++ b/kernel/Base/MeshManipulator_Impl.h
@@ -99,17 +99,17 @@ class EnumHash {
 namespace hpgem {
 namespace Base {
 
-template<std::size_t DIM>
+template <std::size_t DIM>
 void MeshManipulator<DIM>::clearBasisFunctionAssignment() {
     collBasisFSet_.clear();
-    for(Base::Element* element : getElementsList(IteratorType::GLOBAL)) {
+    for (Base::Element *element : getElementsList(IteratorType::GLOBAL)) {
         element->clearBasisFunctions();
     }
 
-    for(Base::Face* face : getFacesList(IteratorType::GLOBAL)) {
+    for (Base::Face *face : getFacesList(IteratorType::GLOBAL)) {
         face->setLocalNumberOfBasisFunctions(0);
     }
-    for(Base::Edge* edge : getEdgesList(IteratorType::GLOBAL)) {
+    for (Base::Edge *edge : getEdgesList(IteratorType::GLOBAL)) {
         edge->setLocalNumberOfBasisFunctions(0);
     }
     if (dimension_ > 1) {

--- a/tests/unit/Base/BasisFunctionChange_UnitTest.cpp
+++ b/tests/unit/Base/BasisFunctionChange_UnitTest.cpp
@@ -1,0 +1,113 @@
+/*
+ This file forms part of hpGEM. This package has been developed over a number of
+ years by various people at the University of Twente and a full list of
+ contributors can be found at http://hpgem.org/about-the-code/team
+
+ This code is distributed using BSD 3-Clause License. A copy of which can found
+ below.
+
+
+ Copyright (c) 2021, University of Twente
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation
+ and/or other materials provided with the distribution.
+
+ 3. Neither the name of the copyright holder nor the names of its contributors
+ may be used to endorse or promote products derived from this software without
+ specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "../catch.hpp"
+#include <cstdlib>
+
+#include "Base/MeshManipulator.h"
+
+// Showing that this is actually more like a self test
+// but there we can't use catch yet.
+#include "../../self/TestMeshes.h"
+
+#ifdef HPGEM_USE_MPI
+#include "mpi.h"
+#endif
+
+// Test to demonstrate that changing the basis function will result in correct
+// basis function count afterwards. Note that switching between different basis
+// functions / order of them may still have residual effects (e.g. the default
+// order of the quadrature).
+
+void initMPI() {
+#ifdef HPGEM_USE_MPI
+    int initialized;
+    MPI_Initialized(&initialized);
+    if (!initialized) {
+        MPI_Init(nullptr, nullptr);
+    }
+    std::atexit([]() { MPI_Finalize(); });
+#endif
+}
+
+using namespace hpgem::Base;
+
+TEST_CASE("Reset CG -> DG", "[MeshManipulator]") {
+    initMPI();
+
+    // 2 unknowns
+    ConfigurationData configData(2);
+    MeshManipulator<3> mesh(&configData);
+    // We get a small but not the smallest 3D mesh. This ensures we have:
+    //  - All three of faces, edges and nodes
+    //  - Both boundary and internal faces, etc.
+    std::vector<std::string> meshes = hpgem::getUnitCubeCubeMeshes(1, 2);
+    mesh.readMesh(meshes[0]);
+
+    // First assign CG, so that we have basis functions on each part
+    mesh.useDefaultDGBasisFunctions(0);
+    // 4-th order so that we have basis functions on all parts
+    mesh.useDefaultConformingBasisFunctions(4, 1);
+
+    // Reset and use DG everywhere with order 0, which means 1 basis function on
+    // each element per unknown.
+    mesh.useDefaultDGBasisFunctions(0);
+    mesh.useDefaultDGBasisFunctions(0, 1);
+
+    // Check these counts
+    INFO("Check Element basis function count");
+    for (const Element* element : mesh.getElementsList()) {
+        CHECK(element->getLocalNumberOfBasisFunctions(0) == 1);
+        CHECK(element->getLocalNumberOfBasisFunctions(1) == 1);
+        REQUIRE(element->getTotalNumberOfBasisFunctions() == 2);
+    }
+    INFO("Check face basis function count");
+    for (const Face* face : mesh.getFacesList()) {
+        REQUIRE(face->getTotalLocalNumberOfBasisFunctions() == 0);
+    }
+
+    INFO("Check edge basis function count");
+    for (const Edge* edge : mesh.getEdgesList()) {
+        REQUIRE(edge->getTotalLocalNumberOfBasisFunctions() == 0);
+    }
+
+    INFO("Check node basis function count");
+    for (const Node* node : mesh.getNodesList()) {
+        REQUIRE(node->getTotalLocalNumberOfBasisFunctions() == 0);
+    }
+}


### PR DESCRIPTION
The basis function count was not reset correctly when switching between different basis functions. 

When changing from CG to DG basis functions on the same mesh (probably does not happen in practice), the number of basis functions on Nodes, Edges and Faces was incorrect.