### PR TITLE
Refactor Problems in DGMax

### DIFF
--- a/applications/DG-Max/Algorithms/DGMaxDiscretization.h
+++ b/applications/DG-Max/Algorithms/DGMaxDiscretization.h
@@ -108,13 +108,12 @@ template <std::size_t DIM>
 class DGMaxDiscretization : public DGMaxDiscretizationBase {
    public:
     using PointPhysicalT = Geometry::PointPhysical<DIM>;
-    using InputFunction = std::function<void(const PointPhysicalT&,
-                                             LinearAlgebra::SmallVector<DIM>&)>;
-    using FaceInputFunction =
-        std::function<void(const PointPhysicalT&, Base::PhysicalFace<DIM>&,
-                           LinearAlgebra::SmallVector<DIM>&)>;
-    using TimeFunction = std::function<void(const PointPhysicalT&, double,
-                                            LinearAlgebra::SmallVector<DIM>&)>;
+    using InputFunction =
+        std::function<LinearAlgebra::SmallVector<DIM>(const PointPhysicalT&)>;
+    using FaceInputFunction = std::function<LinearAlgebra::SmallVector<DIM>(
+        Base::PhysicalFace<DIM>&)>;
+    using TimeFunction = std::function<LinearAlgebra::SmallVector<DIM>(
+        const PointPhysicalT&, double)>;
 
     /// Computed fields of the solution
     struct Fields {

--- a/applications/DG-Max/Algorithms/DGMaxHarmonic.cpp
+++ b/applications/DG-Max/Algorithms/DGMaxHarmonic.cpp
@@ -64,7 +64,7 @@ void DGMaxHarmonic<DIM>::solve(const HarmonicProblem<DIM>& harmonicProblem,
         elementVectors;
     elementVectors[DGMaxDiscretization<DIM>::SOURCE_TERM_VECTOR_ID] =
         std::bind(&HarmonicProblem<DIM>::sourceTerm, std::ref(harmonicProblem),
-                  std::placeholders::_1, std::placeholders::_2);
+                  std::placeholders::_1);
 
     discretization.computeElementIntegrands(
         mesh_, DGMaxDiscretizationBase::NORMAL, elementVectors);
@@ -73,7 +73,7 @@ void DGMaxHarmonic<DIM>::solve(const HarmonicProblem<DIM>& harmonicProblem,
         faceVectors;
     faceVectors[DGMaxDiscretization<DIM>::FACE_VECTOR_ID] = std::bind(
         &HarmonicProblem<DIM>::boundaryCondition, std::ref(harmonicProblem),
-        std::placeholders::_1, std::placeholders::_2, std::placeholders::_3);
+        std::placeholders::_1);
 
     discretization.computeFaceIntegrals(mesh_, DGMaxDiscretizationBase::NORMAL,
                                         faceVectors, stab);
@@ -168,10 +168,9 @@ std::map<typename DGMaxDiscretization<DIM>::NormType, double>
     return computeError(
         norms,
         std::bind(&ExactHarmonicProblem<DIM>::exactSolution, std::ref(problem),
-                  std::placeholders::_1, std::placeholders::_2),
+                  std::placeholders::_1),
         std::bind(&ExactHarmonicProblem<DIM>::exactSolutionCurl,
-                  std::ref(problem), std::placeholders::_1,
-                  std::placeholders::_2));
+                  std::ref(problem), std::placeholders::_1));
 }
 
 template <std::size_t DIM>

--- a/applications/DG-Max/Algorithms/DGMaxHarmonic.cpp
+++ b/applications/DG-Max/Algorithms/DGMaxHarmonic.cpp
@@ -71,9 +71,9 @@ void DGMaxHarmonic<DIM>::solve(const HarmonicProblem<DIM>& harmonicProblem,
 
     std::map<std::size_t, typename DGMaxDiscretization<DIM>::FaceInputFunction>
         faceVectors;
-    faceVectors[DGMaxDiscretization<DIM>::FACE_VECTOR_ID] = std::bind(
-        &HarmonicProblem<DIM>::boundaryCondition, std::ref(harmonicProblem),
-        std::placeholders::_1);
+    faceVectors[DGMaxDiscretization<DIM>::FACE_VECTOR_ID] =
+        std::bind(&HarmonicProblem<DIM>::boundaryCondition,
+                  std::ref(harmonicProblem), std::placeholders::_1);
 
     discretization.computeFaceIntegrals(mesh_, DGMaxDiscretizationBase::NORMAL,
                                         faceVectors, stab);
@@ -165,12 +165,11 @@ std::map<typename DGMaxDiscretization<DIM>::NormType, double>
     DGMaxHarmonic<DIM>::computeError(
         const std::set<typename DGMaxDiscretization<DIM>::NormType>& norms,
         const ExactHarmonicProblem<DIM>& problem) const {
-    return computeError(
-        norms,
-        std::bind(&ExactHarmonicProblem<DIM>::exactSolution, std::ref(problem),
-                  std::placeholders::_1),
-        std::bind(&ExactHarmonicProblem<DIM>::exactSolutionCurl,
-                  std::ref(problem), std::placeholders::_1));
+    return computeError(norms,
+                        std::bind(&ExactHarmonicProblem<DIM>::exactSolution,
+                                  std::ref(problem), std::placeholders::_1),
+                        std::bind(&ExactHarmonicProblem<DIM>::exactSolutionCurl,
+                                  std::ref(problem), std::placeholders::_1));
 }
 
 template <std::size_t DIM>

--- a/applications/DG-Max/Algorithms/DGMaxTimeIntegration.cpp
+++ b/applications/DG-Max/Algorithms/DGMaxTimeIntegration.cpp
@@ -86,14 +86,14 @@ void DGMaxTimeIntegration<DIM>::solve(
 
     elementVectors[DGMaxDiscretizationBase::SOURCE_TERM_VECTOR_ID] =
         std::bind(&SeparableTimeIntegrationProblem<DIM>::sourceTermRef,
-                  std::ref(input), _1, _2);
+                  std::ref(input), _1);
     elementVectors[DGMaxDiscretizationBase::INITIAL_CONDITION_VECTOR_ID] =
         std::bind(&TimeIntegrationProblem<DIM>::initialCondition,
-                  std::ref(input), _1, _2);
+                  std::ref(input), _1);
     elementVectors
         [DGMaxDiscretizationBase::INITIAL_CONDITION_DERIVATIVE_VECTOR_ID] =
             std::bind(&TimeIntegrationProblem<DIM>::initialConditionDerivative,
-                      std::ref(input), _1, _2);
+                      std::ref(input), _1);
 
     discretization.computeElementIntegrands(
         mesh_, DGMaxDiscretizationBase::INVERT, elementVectors);
@@ -102,7 +102,7 @@ void DGMaxTimeIntegration<DIM>::solve(
         faceVectors;
     faceVectors[DGMaxDiscretizationBase::FACE_VECTOR_ID] =
         std::bind(&SeparableTimeIntegrationProblem<DIM>::boundaryConditionRef,
-                  std::ref(input), _1, _2, _3);
+                  std::ref(input), _1);
 
     discretization.computeFaceIntegrals(mesh_, DGMaxDiscretizationBase::INVERT,
                                         faceVectors, parameters.stab);
@@ -393,12 +393,8 @@ void DGMaxTimeIntegration<DIM>::printErrors(
     for (std::size_t level = 0; level < numberOfSnapshots; ++level) {
         double time = snapshotTime[level];
         std::map<NormType, double> normValues = discretization.computeError(
-            mesh_, level,
-            std::bind(exactField, std::placeholders::_1, time,
-                      std::placeholders::_2),
-            std::bind(exactCurl, std::placeholders::_1, time,
-                      std::placeholders::_2),
-            normSet);
+            mesh_, level, std::bind(exactField, std::placeholders::_1, time),
+            std::bind(exactCurl, std::placeholders::_1, time), normSet);
         std::cout << time;
         for (auto norm : norms) {
             std::cout << "\t" << normValues[norm];
@@ -414,10 +410,10 @@ void DGMaxTimeIntegration<DIM>::printErrors(
     printErrors(norms,
                 std::bind(&ExactTimeIntegrationProblem<DIM>::exactSolution,
                           std::ref(problem), std::placeholders::_1,
-                          std::placeholders::_2, std::placeholders::_3),
+                          std::placeholders::_2),
                 std::bind(&ExactTimeIntegrationProblem<DIM>::exactSolutionCurl,
                           std::ref(problem), std::placeholders::_1,
-                          std::placeholders::_2, std::placeholders::_3));
+                          std::placeholders::_2));
 }
 
 template class DGMaxTimeIntegration<2>;

--- a/applications/DG-Max/Algorithms/DivDGMaxDiscretization.cpp
+++ b/applications/DG-Max/Algorithms/DivDGMaxDiscretization.cpp
@@ -1128,14 +1128,10 @@ void DivDGMaxDiscretization<DIM>::faceBoundaryVector(
         }
     } else {
         double diameter = face->getDiameter();
-        const Geometry::PointReference<DIM>& PLeft =
-            face->mapRefFaceToRefElemL(p);
-        const PointPhysicalT PPhys =
-            face->getPtrElementLeft()->referenceToPhysical(PLeft);
 
         LinearAlgebra::SmallVector<DIM> val, phi_curl;
         LinearAlgebra::SmallVector<DIM> phi;
-        boundaryValue(PPhys, fa, val);
+        val = boundaryValue(fa);
 
         std::size_t totalUDoFs =
             face->getPtrElementLeft()->getNumberOfBasisFunctions(0);
@@ -1196,15 +1192,7 @@ LinearAlgebra::MiddleSizeVector
             LinearAlgebra::SmallVector<DIM> basisV;
 
             // Compute boundary value
-            const Base::Face* baseFace = face.getFace();
-            const Geometry::PointReference<DIM - 1>& p =
-                face.getPointReference();
-            const Geometry::PointReference<DIM>& PLeft =
-                baseFace->mapRefFaceToRefElemL(p);
-            const PointPhysicalT PPhys =
-                baseFace->getPtrElementLeft()->referenceToPhysical(PLeft);
-            LinearAlgebra::SmallVector<DIM> val;
-            boundaryValue(PPhys, face, val);
+            LinearAlgebra::SmallVector<DIM> val = boundaryValue(face);
 
             for (std::size_t i = 0; i < faceInfo.totalUDoFs(); ++i) {
                 face.basisFunction(i, basisV, 0);

--- a/applications/DG-Max/Algorithms/DivDGMaxDiscretization.h
+++ b/applications/DG-Max/Algorithms/DivDGMaxDiscretization.h
@@ -131,8 +131,7 @@ class DivDGMaxDiscretization {
     using InputFunction = std::function<void(const PointPhysicalT&,
                                              LinearAlgebra::SmallVector<DIM>&)>;
     using FaceInputFunction =
-        std::function<void(const PointPhysicalT&, Base::PhysicalFace<DIM>&,
-                           LinearAlgebra::SmallVector<DIM>&)>;
+        std::function<LinearAlgebra::SmallVector<DIM>(Base::PhysicalFace<DIM>&)>;
 
     void initializeBasisFunctions(Base::MeshManipulator<DIM>& mesh,
                                   std::size_t order);

--- a/applications/DG-Max/Algorithms/DivDGMaxDiscretization.h
+++ b/applications/DG-Max/Algorithms/DivDGMaxDiscretization.h
@@ -130,8 +130,8 @@ class DivDGMaxDiscretization {
     using PointPhysicalT = Geometry::PointPhysical<DIM>;
     using InputFunction = std::function<void(const PointPhysicalT&,
                                              LinearAlgebra::SmallVector<DIM>&)>;
-    using FaceInputFunction =
-        std::function<LinearAlgebra::SmallVector<DIM>(Base::PhysicalFace<DIM>&)>;
+    using FaceInputFunction = std::function<LinearAlgebra::SmallVector<DIM>(
+        Base::PhysicalFace<DIM>&)>;
 
     void initializeBasisFunctions(Base::MeshManipulator<DIM>& mesh,
                                   std::size_t order);

--- a/applications/DG-Max/Algorithms/DivDGMaxHarmonic.cpp
+++ b/applications/DG-Max/Algorithms/DivDGMaxHarmonic.cpp
@@ -61,13 +61,12 @@ void DivDGMaxHarmonic<DIM>::solve(
     discretization_.computeElementIntegrands(
         mesh_, false,
         std::bind(&HarmonicProblem<DIM>::sourceTerm, std::ref(input),
-                  std::placeholders::_1, std::placeholders::_2),
+                  std::placeholders::_1),
         nullptr, nullptr);
     discretization_.computeFaceIntegrals(
         mesh_,
         std::bind(&HarmonicProblem<DIM>::boundaryCondition, std::ref(input),
-                  std::placeholders::_1, std::placeholders::_2,
-                  std::placeholders::_3),
+                  std::placeholders::_1),
         stab);
 
     Utilities::GlobalIndexing indexing(&mesh_);
@@ -152,8 +151,7 @@ template <std::size_t DIM>
 double DivDGMaxHarmonic<DIM>::computeL2Error(
     const ExactHarmonicProblem<DIM>& problem) const {
     return computeL2Error(std::bind(&ExactHarmonicProblem<DIM>::exactSolution,
-                                    std::ref(problem), std::placeholders::_1,
-                                    std::placeholders::_2));
+                                    std::ref(problem), std::placeholders::_1));
 }
 
 template class DivDGMaxHarmonic<2>;

--- a/applications/DG-Max/ProblemTypes/Harmonic/SampleHarmonicProblems.cpp
+++ b/applications/DG-Max/ProblemTypes/Harmonic/SampleHarmonicProblems.cpp
@@ -74,31 +74,30 @@ double SampleHarmonicProblems<DIM>::omega() const {
 }
 
 template <std::size_t DIM>
-void SampleHarmonicProblems<DIM>::exactSolution(
-    const Geometry::PointPhysical<DIM> &point,
-    LinearAlgebra::SmallVector<DIM> &result) const {
+LinearAlgebra::SmallVector<DIM> SampleHarmonicProblems<DIM>::exactSolution(
+    const Geometry::PointPhysical<DIM> &point) const {
+    LinearAlgebra::SmallVector<DIM> result;
     switch (problem_) {
         case CONSTANT: {
             result.set(1);
             break;
         }
         case SARMANY2010: {
-            sarmanyx(point, result);
-            break;
+            return sarmanyx(point);
         }
         default:
             logger.assert_debug(false, "Not implemented for this problem.");
     }
+    return result;
 }
 
 template <std::size_t DIM>
-void SampleHarmonicProblems<DIM>::exactSolutionCurl(
-    const Geometry::PointPhysical<DIM> &point,
-    LinearAlgebra::SmallVector<DIM> &result) const {
+LinearAlgebra::SmallVector<DIM> SampleHarmonicProblems<DIM>::exactSolutionCurl(
+    const Geometry::PointPhysical<DIM> &point) const {
+    LinearAlgebra::SmallVector<DIM> result;
     switch (problem_) {
         case CONSTANT: {
-            result.set(0);
-            break;
+            return {};
         }
         case SARMANY2010: {
             double x = point[0], y = point[1], z = point[2];
@@ -111,31 +110,31 @@ void SampleHarmonicProblems<DIM>::exactSolutionCurl(
         default:
             logger.assert_debug(false, "Not implemented for this problem.");
     }
+    return result;
 }
 
 template <std::size_t DIM>
-void SampleHarmonicProblems<DIM>::sourceTerm(
-    const Geometry::PointPhysical<DIM> &point,
-    LinearAlgebra::SmallVector<DIM> &result) const {
+LinearAlgebra::SmallVector<DIM> SampleHarmonicProblems<DIM>::sourceTerm(
+    const Geometry::PointPhysical<DIM> &point) const {
+    LinearAlgebra::SmallVector<DIM> result;
     switch (problem_) {
         case CONSTANT: {
             result.set(-omega_ * omega_);
             break;
         }
         case SARMANY2010: {
-            sarmanyx(point, result);
-            result *= (2 * M_PI * M_PI - omega_ * omega_);
-            break;
+            return sarmanyx(point) * (2 * M_PI * M_PI - omega_ * omega_);
         }
         default:
             logger.assert_debug(false, "Not implemented for this problem.");
     }
+    return result;
 }
 
 template <std::size_t DIM>
-void SampleHarmonicProblems<DIM>::sarmanyx(
-    const Geometry::PointPhysical<DIM> &point,
-    LinearAlgebra::SmallVector<DIM> &result) const {
+LinearAlgebra::SmallVector<DIM> SampleHarmonicProblems<DIM>::sarmanyx(
+    const Geometry::PointPhysical<DIM> &point) const {
+    LinearAlgebra::SmallVector<DIM> result;
     if (DIM == 3) {
         double sx = sin(M_PI * point[0]), sy = sin(M_PI * point[1]),
                sz = sin(M_PI * point[2]);
@@ -145,6 +144,7 @@ void SampleHarmonicProblems<DIM>::sarmanyx(
     } else {
         logger.assert_debug(DIM == 3, "Sarmany test case only works in 3D.");
     }
+    return result;
 }
 
 template class SampleHarmonicProblems<2>;

--- a/applications/DG-Max/ProblemTypes/Harmonic/SampleHarmonicProblems.h
+++ b/applications/DG-Max/ProblemTypes/Harmonic/SampleHarmonicProblems.h
@@ -56,21 +56,20 @@ class SampleHarmonicProblems : public ExactHarmonicProblem<DIM> {
     SampleHarmonicProblems(Problem problem, double omega);
 
     double omega() const override;
-    void sourceTerm(const Geometry::PointPhysical<DIM>& point,
-                    LinearAlgebra::SmallVector<DIM>& result) const override;
-    void exactSolution(const Geometry::PointPhysical<DIM>& point,
-                       LinearAlgebra::SmallVector<DIM>& result) const override;
-    void exactSolutionCurl(
-        const Geometry::PointPhysical<DIM>& point,
-        LinearAlgebra::SmallVector<DIM>& result) const override;
+    LinearAlgebra::SmallVector<DIM> sourceTerm(
+        const Geometry::PointPhysical<DIM>& point) const override;
+    LinearAlgebra::SmallVector<DIM> exactSolution(
+        const Geometry::PointPhysical<DIM>& point) const override;
+    LinearAlgebra::SmallVector<DIM> exactSolutionCurl(
+        const Geometry::PointPhysical<DIM>& point) const override;
 
    private:
     const Problem problem_;
     const double omega_;
 
     // x component of Sarmany's solution.
-    void sarmanyx(const Geometry::PointPhysical<DIM>& point,
-                  LinearAlgebra::SmallVector<DIM>& result) const;
+    LinearAlgebra::SmallVector<DIM> sarmanyx(
+        const Geometry::PointPhysical<DIM>& point) const;
 };
 
 #endif  // HPGEM_APP_SAMPLEHARMONICPROBLEMS_H

--- a/applications/DG-Max/ProblemTypes/HarmonicProblem.h
+++ b/applications/DG-Max/ProblemTypes/HarmonicProblem.h
@@ -81,7 +81,8 @@ class ExactHarmonicProblem : public HarmonicProblem<DIM> {
 
     LinearAlgebra::SmallVector<DIM> boundaryCondition(
         Base::PhysicalFace<DIM>& face) const final {
-        LinearAlgebra::SmallVector<DIM> efield = exactSolution(face.getPointPhysical());
+        LinearAlgebra::SmallVector<DIM> efield =
+            exactSolution(face.getPointPhysical());
         const LinearAlgebra::SmallVector<DIM>& normal =
             face.getUnitNormalVector();
         return normal.crossProduct(efield);

--- a/applications/DG-Max/ProblemTypes/HarmonicProblem.h
+++ b/applications/DG-Max/ProblemTypes/HarmonicProblem.h
@@ -65,33 +65,26 @@ class HarmonicProblem {
    public:
     virtual ~HarmonicProblem() = default;
     virtual double omega() const = 0;
-    virtual void sourceTerm(const Geometry::PointPhysical<DIM>& point,
-                            LinearAlgebra::SmallVector<DIM>& result) const = 0;
-    virtual void boundaryCondition(
-        const Geometry::PointPhysical<DIM>& point,
-        Base::PhysicalFace<DIM>& face,
-        LinearAlgebra::SmallVector<DIM>& result) const = 0;
+    virtual LinearAlgebra::SmallVector<DIM> sourceTerm(
+        const Geometry::PointPhysical<DIM>& point) const = 0;
+    virtual LinearAlgebra::SmallVector<DIM> boundaryCondition(
+        Base::PhysicalFace<DIM>& face) const = 0;
 };
 
 template <std::size_t DIM>
 class ExactHarmonicProblem : public HarmonicProblem<DIM> {
    public:
-    virtual void exactSolution(
-        const Geometry::PointPhysical<DIM>& point,
-        LinearAlgebra::SmallVector<DIM>& result) const = 0;
-    virtual void exactSolutionCurl(
-        const Geometry::PointPhysical<DIM>& point,
-        LinearAlgebra::SmallVector<DIM>& result) const = 0;
+    virtual LinearAlgebra::SmallVector<DIM> exactSolution(
+        const Geometry::PointPhysical<DIM>& point) const = 0;
+    virtual LinearAlgebra::SmallVector<DIM> exactSolutionCurl(
+        const Geometry::PointPhysical<DIM>& point) const = 0;
 
-    void boundaryCondition(
-        const Geometry::PointPhysical<DIM>& point,
-        Base::PhysicalFace<DIM>& face,
-        LinearAlgebra::SmallVector<DIM>& result) const final {
-        LinearAlgebra::SmallVector<DIM> sol;
-        exactSolution(point, sol);
+    LinearAlgebra::SmallVector<DIM> boundaryCondition(
+        Base::PhysicalFace<DIM>& face) const final {
+        LinearAlgebra::SmallVector<DIM> efield = exactSolution(face.getPointPhysical());
         const LinearAlgebra::SmallVector<DIM>& normal =
             face.getUnitNormalVector();
-        normal.crossProduct(sol, result);
+        return normal.crossProduct(efield);
     }
 };
 

--- a/applications/DG-Max/ProblemTypes/Time/DummyTestProblem.cpp
+++ b/applications/DG-Max/ProblemTypes/Time/DummyTestProblem.cpp
@@ -41,8 +41,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 using namespace hpgem;
 
 template <std::size_t DIM>
-LinearAlgebra::SmallVector<DIM> DummyTestProblem<DIM>::initialConditionDerivative(
-    const Geometry::PointPhysical<DIM> &point) const {
+LinearAlgebra::SmallVector<DIM>
+    DummyTestProblem<DIM>::initialConditionDerivative(
+        const Geometry::PointPhysical<DIM> &point) const {
     return {};
 }
 

--- a/applications/DG-Max/ProblemTypes/Time/DummyTestProblem.cpp
+++ b/applications/DG-Max/ProblemTypes/Time/DummyTestProblem.cpp
@@ -41,18 +41,15 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 using namespace hpgem;
 
 template <std::size_t DIM>
-void DummyTestProblem<DIM>::initialConditionDerivative(
-    const Geometry::PointPhysical<DIM> &point,
-    LinearAlgebra::SmallVector<DIM> &result) const {
-    for (std::size_t i = 0; i < DIM; i++) {
-        result[i] = 0;
-    }
+LinearAlgebra::SmallVector<DIM> DummyTestProblem<DIM>::initialConditionDerivative(
+    const Geometry::PointPhysical<DIM> &point) const {
+    return {};
 }
 
 template <std::size_t DIM>
-void DummyTestProblem<DIM>::exactSolution(
-    const Geometry::PointPhysical<DIM> &p, double t,
-    LinearAlgebra::SmallVector<DIM> &ret) const {
+LinearAlgebra::SmallVector<DIM> DummyTestProblem<DIM>::exactSolution(
+    const Geometry::PointPhysical<DIM> &p, double t) const {
+    LinearAlgebra::SmallVector<DIM> ret;
     // TODO: Code literaly copied, no verification
     // ret[0]=sin(M_PI*2*p[1])*sin(M_PI*2*p[2]);
     // ret[1]=sin(M_PI*2*p[2])*sin(M_PI*2*p[0]);
@@ -71,12 +68,13 @@ void DummyTestProblem<DIM>::exactSolution(
     //     ret[0]=p[0]*(1-p[0]);
     //     ret[1]=0;
     // 	   ret[2]=0;
+    return ret;
 }
 
 template <std::size_t DIM>
-void DummyTestProblem<DIM>::exactSolutionCurl(
-    const Geometry::PointPhysical<DIM> &p, double t,
-    LinearAlgebra::SmallVector<DIM> &ret) const {
+LinearAlgebra::SmallVector<DIM> DummyTestProblem<DIM>::exactSolutionCurl(
+    const Geometry::PointPhysical<DIM> &p, double t) const {
+    LinearAlgebra::SmallVector<DIM> ret;
     // TODO: Code literaly copied, no verification
     // ret[0]=sin(M_PI*2*p[0])*(cos(M_PI*2*p[1])-cos(M_PI*2*p[2]));
     // ret[1]=sin(M_PI*2*p[1])*(cos(M_PI*2*p[2])-cos(M_PI*2*p[0]));
@@ -94,6 +92,7 @@ void DummyTestProblem<DIM>::exactSolutionCurl(
     // ret[2] = 1.0;
 
     //          ret[0]=0;ret[1]=0;ret[2]=0;
+    return ret;
 }
 
 template <std::size_t DIM>
@@ -104,10 +103,9 @@ double DummyTestProblem<DIM>::timeScalingBoundary(double t) const {
 }
 
 template <std::size_t DIM>
-void DummyTestProblem<DIM>::sourceTermRef(
-    const Geometry::PointPhysical<DIM> &point,
-    LinearAlgebra::SmallVector<DIM> &result) const {
-    exactSolution(point, 0, result);
+LinearAlgebra::SmallVector<DIM> DummyTestProblem<DIM>::sourceTermRef(
+    const Geometry::PointPhysical<DIM> &point) const {
+    LinearAlgebra::SmallVector<DIM> result = exactSolution(point, 0);
     // 	ret*=-1;
     // ret*=M_PI*M_PI*8-1;
     result *= M_PI * M_PI * 2 - 1;
@@ -116,6 +114,8 @@ void DummyTestProblem<DIM>::sourceTermRef(
     // ret[0] = 0.0;
     // ret[1] = 0.0;
     // ret[2] = 0.0;
+
+    return result;
 }
 
 template <std::size_t DIM>

--- a/applications/DG-Max/ProblemTypes/Time/DummyTestProblem.h
+++ b/applications/DG-Max/ProblemTypes/Time/DummyTestProblem.h
@@ -50,18 +50,16 @@ using namespace hpgem;
 /// TODO: Cleanup the implementation to make all problems accessiblea
 template <std::size_t DIM>
 class DummyTestProblem : public ExactSeparableTimeIntegrationProblem<DIM> {
-    void initialConditionDerivative(
-        const Geometry::PointPhysical<DIM>& point,
-        LinearAlgebra::SmallVector<DIM>& result) const override;
+    LinearAlgebra::SmallVector<DIM> initialConditionDerivative(
+        const Geometry::PointPhysical<DIM>& point) const override;
 
-    void sourceTermRef(const Geometry::PointPhysical<DIM>& point,
-                       LinearAlgebra::SmallVector<DIM>& result) const override;
+    LinearAlgebra::SmallVector<DIM> sourceTermRef(
+        const Geometry::PointPhysical<DIM>& point) const override;
 
-    void exactSolution(const Geometry::PointPhysical<DIM>& point, double t,
-                       LinearAlgebra::SmallVector<DIM>& result) const override;
-    void exactSolutionCurl(
-        const Geometry::PointPhysical<DIM>& point, double t,
-        LinearAlgebra::SmallVector<DIM>& result) const override;
+    LinearAlgebra::SmallVector<DIM> exactSolution(
+        const Geometry::PointPhysical<DIM>& point, double t) const override;
+    LinearAlgebra::SmallVector<DIM> exactSolutionCurl(
+        const Geometry::PointPhysical<DIM>& point, double t) const override;
 
     double timeScalingBoundary(double t) const override;
     double timeScalingSource(double t) const override;

--- a/applications/DG-Max/ProblemTypes/Time/SampleTestProblems.cpp
+++ b/applications/DG-Max/ProblemTypes/Time/SampleTestProblems.cpp
@@ -46,8 +46,9 @@ SampleTestProblems<DIM>::SampleTestProblems(
     : problem_(problem) {}
 
 template <std::size_t DIM>
-LinearAlgebra::SmallVector<DIM> SampleTestProblems<DIM>::initialConditionDerivative(
-    const Geometry::PointPhysical<DIM> &point) const {
+LinearAlgebra::SmallVector<DIM>
+    SampleTestProblems<DIM>::initialConditionDerivative(
+        const Geometry::PointPhysical<DIM> &point) const {
     LinearAlgebra::SmallVector<DIM> result;
     switch (problem_) {
         case CONSTANT: {

--- a/applications/DG-Max/ProblemTypes/Time/SampleTestProblems.cpp
+++ b/applications/DG-Max/ProblemTypes/Time/SampleTestProblems.cpp
@@ -46,12 +46,12 @@ SampleTestProblems<DIM>::SampleTestProblems(
     : problem_(problem) {}
 
 template <std::size_t DIM>
-void SampleTestProblems<DIM>::initialConditionDerivative(
-    const Geometry::PointPhysical<DIM> &point,
-    LinearAlgebra::SmallVector<DIM> &result) const {
+LinearAlgebra::SmallVector<DIM> SampleTestProblems<DIM>::initialConditionDerivative(
+    const Geometry::PointPhysical<DIM> &point) const {
+    LinearAlgebra::SmallVector<DIM> result;
     switch (problem_) {
         case CONSTANT: {
-            result.set(0);
+            // 0
             break;
         }
         case LINEAR: {
@@ -59,52 +59,51 @@ void SampleTestProblems<DIM>::initialConditionDerivative(
             break;
         }
         case SINSIN: {
-            sinx(point, result);
             // d sin(pi t)/dt at t = 0.
-            result *= M_PI;
+            result = sinx(point) * M_PI;
             break;
         }
         case SARMANY2013: {
             // Derivatives of all three cosines are 0.
-            result.set(0);
             break;
         }
         default:
             logger.assert_debug(false, "Unknown problem");
     }
+    return result;
 }
 
 template <std::size_t DIM>
-void SampleTestProblems<DIM>::sourceTermRef(
-    const Geometry::PointPhysical<DIM> &point,
-    LinearAlgebra::SmallVector<DIM> &result) const {
+LinearAlgebra::SmallVector<DIM> SampleTestProblems<DIM>::sourceTermRef(
+    const Geometry::PointPhysical<DIM> &point) const {
+    LinearAlgebra::SmallVector<DIM> result;
     switch (problem_) {
         case CONSTANT: {
-            result.set(0);
+            // 0
             break;
         }
         case LINEAR: {
-            result.set(0);
+            // 0
             break;
         }
         case SINSIN: {
-            sinx(point, result);
-            result *= -M_PI * M_PI;
+            result = sinx(point) * -M_PI * M_PI;
             break;
         }
         case SARMANY2013: {
-            sarmany2013x(point, result);
+            result = sarmany2013x(point);
             break;
         }
         default:
             logger.assert_debug(false, "Unknown problem");
     }
+    return result;
 }
 
 template <std::size_t DIM>
-void SampleTestProblems<DIM>::exactSolution(
-    const Geometry::PointPhysical<DIM> &point, double t,
-    LinearAlgebra::SmallVector<DIM> &result) const {
+LinearAlgebra::SmallVector<DIM> SampleTestProblems<DIM>::exactSolution(
+    const Geometry::PointPhysical<DIM> &point, double t) const {
+    LinearAlgebra::SmallVector<DIM> result;
     switch (problem_) {
         case CONSTANT: {
             result.set(1);
@@ -115,29 +114,29 @@ void SampleTestProblems<DIM>::exactSolution(
             break;
         }
         case SINSIN: {
-            sinx(point, result);
-            result *= sin(M_PI * t);
+            result = sinx(point) * sin(M_PI * t);
             break;
         }
         case SARMANY2013: {
-            sarmany2013x(point, result);
+            result = sarmany2013x(point);
             result *= (cos(t) + cos(t / 2) + cos(t / 3));
             break;
         }
         default:
             logger.assert_debug(false, "Unknown problem");
     }
+    return result;
 }
 
 template <std::size_t DIM>
-void SampleTestProblems<DIM>::exactSolutionCurl(
-    const Geometry::PointPhysical<DIM> &point, double t,
-    LinearAlgebra::SmallVector<DIM> &result) const {
+LinearAlgebra::SmallVector<DIM> SampleTestProblems<DIM>::exactSolutionCurl(
+    const Geometry::PointPhysical<DIM> &point, double t) const {
+    LinearAlgebra::SmallVector<DIM> result;
     switch (problem_) {
         case CONSTANT:
         case LINEAR:
         case SINSIN: {
-            result.set(0);
+            // 0
             break;
         }
         case SARMANY2013: {
@@ -157,6 +156,7 @@ void SampleTestProblems<DIM>::exactSolutionCurl(
         default:
             logger.assert_debug(false, "Unknown problem");
     }
+    return result;
 }
 
 template <std::size_t DIM>
@@ -216,20 +216,21 @@ double SampleTestProblems<DIM>::timeScalingSource(double t) const {
 }
 
 template <std::size_t DIM>
-void SampleTestProblems<DIM>::sinx(
-    const Geometry::PointPhysical<DIM> &point,
-    LinearAlgebra::SmallVector<DIM> &result) const {
+LinearAlgebra::SmallVector<DIM> SampleTestProblems<DIM>::sinx(
+    const Geometry::PointPhysical<DIM> &point) const {
+    LinearAlgebra::SmallVector<DIM> result;
     for (int i = 0; i < DIM; ++i) {
         double v = sin(M_PI * point[i]);
         v *= v;
         result[i] = v;
     }
+    return result;
 }
 
 template <std::size_t DIM>
-void SampleTestProblems<DIM>::sarmany2013x(
-    const Geometry::PointPhysical<DIM> &point,
-    LinearAlgebra::SmallVector<DIM> &result) const {
+LinearAlgebra::SmallVector<DIM> SampleTestProblems<DIM>::sarmany2013x(
+    const Geometry::PointPhysical<DIM> &point) const {
+    LinearAlgebra::SmallVector<DIM> result;
     if (DIM == 3) {
         double sx = sin(M_PI * point[0]), sy = sin(M_PI * point[1]),
                sz = sin(M_PI * point[2]);
@@ -239,6 +240,7 @@ void SampleTestProblems<DIM>::sarmany2013x(
     } else {
         logger.assert_debug(DIM == 3, "Sarmany test case only works in 3D.");
     }
+    return result;
 }
 
 template class SampleTestProblems<2>;

--- a/applications/DG-Max/ProblemTypes/Time/SampleTestProblems.h
+++ b/applications/DG-Max/ProblemTypes/Time/SampleTestProblems.h
@@ -62,17 +62,15 @@ class SampleTestProblems : public ExactSeparableTimeIntegrationProblem<DIM> {
 
     SampleTestProblems(Problem problem);
 
-    void initialConditionDerivative(
-        const Geometry::PointPhysical<DIM>& point,
-        LinearAlgebra::SmallVector<DIM>& result) const override;
-    void sourceTermRef(const Geometry::PointPhysical<DIM>& point,
-                       LinearAlgebra::SmallVector<DIM>& result) const override;
+    LinearAlgebra::SmallVector<DIM> initialConditionDerivative(
+        const Geometry::PointPhysical<DIM>& point) const override;
+    LinearAlgebra::SmallVector<DIM> sourceTermRef(
+        const Geometry::PointPhysical<DIM>& point) const override;
 
-    void exactSolution(const Geometry::PointPhysical<DIM>& point, double t,
-                       LinearAlgebra::SmallVector<DIM>& result) const override;
-    void exactSolutionCurl(
-        const Geometry::PointPhysical<DIM>& point, double t,
-        LinearAlgebra::SmallVector<DIM>& result) const override;
+    LinearAlgebra::SmallVector<DIM> exactSolution(
+        const Geometry::PointPhysical<DIM>& point, double t) const override;
+    LinearAlgebra::SmallVector<DIM> exactSolutionCurl(
+        const Geometry::PointPhysical<DIM>& point, double t) const override;
 
     double referenceTimeBoundary() const override;
 
@@ -85,11 +83,11 @@ class SampleTestProblems : public ExactSeparableTimeIntegrationProblem<DIM> {
 
     /// Helper function for the SINSIN test case, computing the basis field
     /// strength.
-    void sinx(const Geometry::PointPhysical<DIM>& point,
-              LinearAlgebra::SmallVector<DIM>& result) const;
+    LinearAlgebra::SmallVector<DIM> sinx(
+        const Geometry::PointPhysical<DIM>& point) const;
     // Helper function for the SARMANY2013 case with the electric field
-    void sarmany2013x(const Geometry::PointPhysical<DIM>& point,
-                      LinearAlgebra::SmallVector<DIM>& result) const;
+    LinearAlgebra::SmallVector<DIM> sarmany2013x(
+        const Geometry::PointPhysical<DIM>& point) const;
 };
 
 #endif  // HPGEM_APP_SAMPLETESTPROBLEMS_H


### PR DESCRIPTION
The problem definitions for DGMax define many functions that go into the
PDE, for example boundary values and source terms. These functions are
refactored here to be more readable. In particular the follow changes
have been made:
 - Replaced returning the results by reference to just by value, thus:
   refactoring  void f(...., Vector<DIM>& result) to Vector<DIM> f(....)
 - Removed passing both a PointPhysical and a PhysicalFace. The latter
   contains the current point of evaluation, removing the need for the
   former.

The rest of the refactoring is just adjusting the code to work with the new signatures. The only cleanup considered was removing now unused variables.

Note #138 introduces a new source problem, so depending on merge order one of them needs to be adjusted.