### PR TITLE
Refactor DGMaxDiscretization matrix construction

### DIFF
--- a/applications/DG-Max/Algorithms/DGMaxDiscretization.cpp
+++ b/applications/DG-Max/Algorithms/DGMaxDiscretization.cpp
@@ -41,9 +41,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <complex>
 
 #include "Base/HCurlConformingTransformation.h"
+#include "Base/H1ConformingTransformation.h"
 #include "Base/MeshManipulator.h"
-#include "Integration/ElementIntegral.h"
-#include "Integration/FaceIntegral.h"
 
 #include "ElementInfos.h"
 
@@ -60,6 +59,20 @@ const std::size_t DGMaxDiscretizationBase::SOURCE_TERM_VECTOR_ID;
 
 const std::size_t DGMaxDiscretizationBase::FACE_MATRIX_ID;
 const std::size_t DGMaxDiscretizationBase::FACE_VECTOR_ID;
+
+template <std::size_t DIM>
+DGMaxDiscretization<DIM>::DGMaxDiscretization(bool includeProjector)
+    : includeProjector_(includeProjector), matrixHandling_(NORMAL) {
+
+    transforms_.emplace_back(new Base::HCurlConformingTransformation<DIM>());
+    if (includeProjector_) {
+        transforms_.emplace_back(new Base::H1ConformingTransformation<DIM>());
+    }
+    for (std::size_t i = 0; i < transforms_.size(); ++i) {
+        elementIntegrator_.setTransformation(transforms_[i], i);
+        faceIntegrator_.setTransformation(transforms_[i], i);
+    }
+}
 
 template <std::size_t DIM>
 void DGMaxDiscretization<DIM>::initializeBasisFunctions(
@@ -86,25 +99,12 @@ void DGMaxDiscretization<DIM>::initializeBasisFunctions(
 
 template <std::size_t DIM>
 void DGMaxDiscretization<DIM>::computeElementIntegrands(
-    Base::MeshManipulator<DIM>& mesh, MassMatrixHandling massMatrixHandling,
-    const std::map<std::size_t, InputFunction>& elementVectors) const {
+    Base::MeshManipulator<DIM>& mesh,
+    const std::map<std::size_t, InputFunction>& elementVectors) {
     logger.assert_always(
-        !(massMatrixHandling == ORTHOGONALIZE && !elementVectors.empty()),
+        !(matrixHandling_ == ORTHOGONALIZE && !elementVectors.empty()),
         "Mass matrix rescale with input functions is not implemented");
-    LinearAlgebra::MiddleSizeMatrix massMatrix(1, 1), stiffnessMatrix(1, 1),
-        projectorMatrix(0, 0);
     LinearAlgebra::MiddleSizeVector tempElementVector;
-    Integration::ElementIntegral<DIM> elIntegral;
-
-    elIntegral.setTransformation(
-        std::shared_ptr<Base::CoordinateTransformation<DIM>>(
-            new Base::HCurlConformingTransformation<DIM>()));
-    if (includeProjector_) {
-        elIntegral.setTransformation(
-            std::shared_ptr<Base::CoordinateTransformation<DIM>>(
-                new Base::H1ConformingTransformation<DIM>()),
-            1);
-    }
 
     // Using the Global iterator as:
     //  - The projector needs to integration over all elements on which the
@@ -117,94 +117,16 @@ void DGMaxDiscretization<DIM>::computeElementIntegrands(
              mesh.elementColBegin(Base::IteratorType::GLOBAL);
          it != end; ++it) {
         Base::Element* element = *it;
-        std::size_t numberOfBasisFunctions =
-            element->getNumberOfBasisFunctions(0);
 
-        // TODO: Are these resizes needed, as the content seems to be
-        // overwritten by the integral.
-        massMatrix.resize(numberOfBasisFunctions, numberOfBasisFunctions);
-        massMatrix = elIntegral.integrate(
-            element, [&](Base::PhysicalElement<DIM>& pelement) {
-                LinearAlgebra::MiddleSizeMatrix res;
-                elementMassMatrix(pelement, res);
-                return res;
-            });
-        switch (massMatrixHandling) {
-            case DGMaxDiscretizationBase::NORMAL:
-                break;
-            case DGMaxDiscretizationBase::INVERT:
-                massMatrix = massMatrix.inverse();
-                break;
-            case DGMaxDiscretizationBase::ORTHOGONALIZE:
-                massMatrix.cholesky();
-                break;
-            default:
-                logger.assert_always(false,
-                                     "Not implemented mass matrix handling");
-        }
-        element->setElementMatrix(massMatrix, MASS_MATRIX_ID);
-
-        stiffnessMatrix.resize(numberOfBasisFunctions, numberOfBasisFunctions);
-        stiffnessMatrix = elIntegral.integrate(
-            element, [&](Base::PhysicalElement<DIM>& pelement) {
-                LinearAlgebra::MiddleSizeMatrix res;
-                elementStiffnessMatrix(pelement, res);
-                return res;
-            });
-        if (massMatrixHandling == DGMaxDiscretizationBase::ORTHOGONALIZE) {
-            // Compute L^{-1} S L^{-H}, where S is the stiffness matrix and
-            // LL^H is the mass matrix.
-            LinearAlgebra::MiddleSizeMatrix original = stiffnessMatrix;
-            massMatrix.solveLowerTriangular(stiffnessMatrix,
-                                            LinearAlgebra::Side::OP_LEFT,
-                                            LinearAlgebra::Transpose::NOT);
-            massMatrix.solveLowerTriangular(
-                stiffnessMatrix, LinearAlgebra::Side::OP_RIGHT,
-                LinearAlgebra::Transpose::HERMITIAN_TRANSPOSE);
-            // Due to rounding errors the matrix might be slightly non
-            // Hermitian, fix this by replacing S by 0.5(S + S^H).
-            for (std::size_t i = 0; i < stiffnessMatrix.getNumberOfRows();
-                 ++i) {
-                stiffnessMatrix(i, i) = std::real(stiffnessMatrix(i, i));
-                for (std::size_t j = i;
-                     j < stiffnessMatrix.getNumberOfColumns(); ++j) {
-                    std::complex<double> upper =
-                        0.5 * (stiffnessMatrix(i, j) +
-                               std::conj(stiffnessMatrix(j, i)));
-                    stiffnessMatrix(i, j) = upper;
-                    stiffnessMatrix(j, i) = std::conj(upper);
-                }
-            }
-        }
-        element->setElementMatrix(stiffnessMatrix, STIFFNESS_MATRIX_ID);
-
-        if (includeProjector_) {
-            std::size_t numberOfProjectorBasisFunctions =
-                element->getNumberOfBasisFunctions(1);
-            projectorMatrix.resize(numberOfProjectorBasisFunctions,
-                                   numberOfBasisFunctions);
-            projectorMatrix = elIntegral.integrate(
-                element, [&](Base::PhysicalElement<DIM>& pelement) {
-                    LinearAlgebra::MiddleSizeMatrix res;
-                    elementProjectorMatrix(pelement, res);
-                    return res;
-                });
-
-            if (massMatrixHandling == DGMaxDiscretizationBase::ORTHOGONALIZE) {
-                // Compute B L^{-H}, where B is the projector matrix and L is
-                // the Cholesky factor of the mass matrix.
-                massMatrix.solveLowerTriangular(
-                    projectorMatrix, LinearAlgebra::Side::OP_RIGHT,
-                    LinearAlgebra::Transpose::HERMITIAN_TRANSPOSE);
-            }
-
-            element->setElementMatrix(projectorMatrix, PROJECTOR_MATRIX_ID);
-        }
+        computeElementMatrices(element);
+        postProcessElementMatrices(element);
 
         for (auto const& elementVectorDef : elementVectors) {
+            std::size_t numberOfBasisFunctions =
+                element->getNumberOfBasisFunctions(0);
             tempElementVector.resize(numberOfBasisFunctions);
             if (elementVectorDef.second) {
-                tempElementVector = elIntegral.integrate(
+                tempElementVector = elementIntegrator_.integrate(
                     element, [&](Base::PhysicalElement<DIM>& element) {
                         LinearAlgebra::MiddleSizeVector res;
                         elementInnerProduct(element, elementVectorDef.second,
@@ -220,9 +142,10 @@ void DGMaxDiscretization<DIM>::computeElementIntegrands(
 
 template <std::size_t DIM>
 void DGMaxDiscretization<DIM>::computeFaceIntegrals(
-    Base::MeshManipulator<DIM>& mesh, MassMatrixHandling massMatrixHandling,
+    Base::MeshManipulator<DIM>& mesh,
     const std::map<std::size_t, FaceInputFunction>& boundaryVectors,
-    double stab) const {
+    double stab) {
+    MassMatrixHandling massMatrixHandling = matrixHandling_;
     logger.assert_always(
         !(massMatrixHandling == ORTHOGONALIZE && !boundaryVectors.empty()),
         "Rescale not implemented in combination with boundary conditions");
@@ -242,63 +165,15 @@ void DGMaxDiscretization<DIM>::computeFaceIntegrals(
          it != end; ++it) {
         Base::Face* face = *it;
 
-        // Resize all the matrices and vectors;
+        computeFaceMatrix(face, stab);
+        postProcessFaceMatrices(face);
+
         std::size_t numberOfBasisFunctions =
             face->getPtrElementLeft()->getNumberOfBasisFunctions(0);
         if (face->isInternal()) {
             numberOfBasisFunctions +=
                 face->getPtrElementRight()->getNumberOfBasisFunctions(0);
         }
-
-        stiffnessFaceMatrix.resize(numberOfBasisFunctions,
-                                   numberOfBasisFunctions);
-        tempFaceVector.resize(numberOfBasisFunctions);
-
-        // Compute the actual face  integrals.
-        stiffnessFaceMatrix =
-            faIntegral.integrate(face, [&](Base::PhysicalFace<DIM>& pface) {
-                LinearAlgebra::MiddleSizeMatrix res;
-                faceMatrix(pface, res);
-                LinearAlgebra::MiddleSizeMatrix temp;
-                facePenaltyMatrix(pface, temp, stab);
-                res += temp;
-                return res;
-            });
-        if (massMatrixHandling == DGMaxDiscretizationBase::ORTHOGONALIZE) {
-            massMatrix.resize(numberOfBasisFunctions, numberOfBasisFunctions);
-            massMatrix *= 0.0;  // Clear the contents
-            const LinearAlgebra::MiddleSizeMatrix& leftMassMat =
-                face->getPtrElementLeft()->getElementMatrix(MASS_MATRIX_ID);
-            std::size_t leftRows = leftMassMat.getNumberOfRows();
-            // Copy lower triagonal part
-            for (std::size_t i = 0; i < leftRows; ++i) {
-                for (std::size_t j = i; j < leftRows; ++j) {
-                    massMatrix(j, i) = leftMassMat(j, i);
-                }
-            }
-            if (face->isInternal()) {
-                const LinearAlgebra::MiddleSizeMatrix& rightMassMat =
-                    face->getPtrElementRight()->getElementMatrix(
-                        MASS_MATRIX_ID);
-                std::size_t rightRows = rightMassMat.getNumberOfRows();
-                // Copy lower triagonal part, now offset by leftRows.
-                for (std::size_t i = 0; i < rightRows; ++i) {
-                    for (std::size_t j = i; j < rightRows; ++j) {
-                        massMatrix(leftRows + j, leftRows + i) =
-                            rightMassMat(j, i);
-                    }
-                }
-            }
-            LinearAlgebra::MiddleSizeMatrix original = stiffnessFaceMatrix;
-            // Rescaling
-            massMatrix.solveLowerTriangular(stiffnessFaceMatrix,
-                                            hpgem::LinearAlgebra::Side::OP_LEFT,
-                                            LinearAlgebra::Transpose::NOT);
-            massMatrix.solveLowerTriangular(
-                stiffnessFaceMatrix, hpgem::LinearAlgebra::Side::OP_RIGHT,
-                LinearAlgebra::Transpose::HERMITIAN_TRANSPOSE);
-        }
-        face->setFaceMatrix(stiffnessFaceMatrix, FACE_MATRIX_ID);
 
         for (auto const& faceVectorDef : boundaryVectors) {
             tempFaceVector.resize(numberOfBasisFunctions);
@@ -316,60 +191,121 @@ void DGMaxDiscretization<DIM>::computeFaceIntegrals(
 }
 
 template <std::size_t DIM>
-void DGMaxDiscretization<DIM>::elementMassMatrix(
-    Base::PhysicalElement<DIM>& el,
-    LinearAlgebra::MiddleSizeMatrix& ret) const {
-    const Base::Element* element = el.getElement();
-    const std::size_t numberOfBasisFunctions =
-        element->getNumberOfBasisFunctions(0);
-    ret.resize(numberOfBasisFunctions, numberOfBasisFunctions);
-    LinearAlgebra::SmallVector<DIM> phi_i, phi_j;
-    double epsilon =
-        static_cast<ElementInfos*>(element->getUserData())->epsilon_;
-    for (std::size_t i = 0; i < numberOfBasisFunctions; ++i) {
-        el.basisFunction(i, phi_i, 0);
-        for (std::size_t j = 0; j < numberOfBasisFunctions; ++j) {
-            el.basisFunction(j, phi_j, 0);
-            ret(i, j) = phi_i * phi_j * epsilon;
-            ret(j, i) = ret(i, j);
-        }
-    }
-}
-
-template <std::size_t DIM>
-void DGMaxDiscretization<DIM>::elementStiffnessMatrix(
-    Base::PhysicalElement<DIM>& el,
-    LinearAlgebra::MiddleSizeMatrix& ret) const {
-    const Base::Element* element = el.getElement();
-    const std::size_t numberOfBasisFunctions =
-        element->getNumberOfBasisFunctions(0);
-    ret.resize(numberOfBasisFunctions, numberOfBasisFunctions);
-    LinearAlgebra::SmallVector<DIM> phi_i, phi_j;
-    for (std::size_t i = 0; i < numberOfBasisFunctions; ++i) {
-        phi_i = el.basisFunctionCurl(i, 0);
-        for (std::size_t j = i; j < numberOfBasisFunctions; ++j) {
-            phi_j = el.basisFunctionCurl(j, 0);
-            ret(i, j) = phi_i * phi_j;
-            ret(j, i) = ret(i, j);
-        }
-    }
-}
-
-template <std::size_t DIM>
-void DGMaxDiscretization<DIM>::elementProjectorMatrix(
-    Base::PhysicalElement<DIM>& el,
-    LinearAlgebra::MiddleSizeMatrix& ret) const {
-    const Base::Element* element = el.getElement();
-    double epsilon =
+void DGMaxDiscretization<DIM>::computeElementMatrices(Base::Element* element) {
+    // Shared information
+    const double epsilon =
         static_cast<ElementInfos*>(element->getUserData())->epsilon_;
     const std::size_t dofU = element->getNumberOfBasisFunctions(0);
-    const std::size_t dofP = element->getNumberOfBasisFunctions(1);
-    ret.resize(dofP, dofU);
-    LinearAlgebra::SmallVector<DIM> phiU;
-    for (std::size_t i = 0; i < dofU; ++i) {
-        el.basisFunction(i, phiU, 0);
-        for (std::size_t j = 0; j < dofP; ++j) {
-            ret(j, i) = epsilon * phiU * el.basisFunctionDeriv(j, 1);
+
+    // Mass matrix
+    LinearAlgebra::MiddleSizeMatrix massMatrix = elementIntegrator_.integrate(
+        element, [&](Base::PhysicalElement<DIM>& pel) {
+            LinearAlgebra::MiddleSizeMatrix ret;
+            ret.resize(dofU, dofU);
+            LinearAlgebra::SmallVector<DIM> phi_i, phi_j;
+            for (std::size_t i = 0; i < dofU; ++i) {
+                pel.basisFunction(i, phi_i, 0);
+                for (std::size_t j = 0; j < dofU; ++j) {
+                    pel.basisFunction(j, phi_j, 0);
+                    ret(i, j) = phi_i * phi_j * epsilon;
+                    ret(j, i) = ret(i, j);
+                }
+            }
+            return ret;
+        });
+    element->setElementMatrix(massMatrix, MASS_MATRIX_ID);
+    // Stiffness matrix
+    LinearAlgebra::MiddleSizeMatrix stiffnessMatrix =
+        elementIntegrator_.integrate(
+            element, [&element, &dofU](Base::PhysicalElement<DIM>& pel) {
+                LinearAlgebra::MiddleSizeMatrix ret;
+                ret.resize(dofU, dofU);
+                LinearAlgebra::SmallVector<DIM> phi_i, phi_j;
+                for (std::size_t i = 0; i < dofU; ++i) {
+                    phi_i = pel.basisFunctionCurl(i, 0);
+                    for (std::size_t j = i; j < dofU; ++j) {
+                        phi_j = pel.basisFunctionCurl(j, 0);
+                        ret(i, j) = phi_i * phi_j;
+                        ret(j, i) = ret(i, j);
+                    }
+                }
+                return ret;
+            });
+    element->setElementMatrix(stiffnessMatrix, STIFFNESS_MATRIX_ID);
+    if (includeProjector_) {
+        LinearAlgebra::MiddleSizeMatrix projectorMatrix =
+            elementIntegrator_.integrate(
+                element, [&](Base::PhysicalElement<DIM>& pel) {
+                    LinearAlgebra::MiddleSizeMatrix ret;
+                    const std::size_t dofP =
+                        element->getNumberOfBasisFunctions(1);
+                    ret.resize(dofP, dofU);
+                    LinearAlgebra::SmallVector<DIM> phiU;
+                    for (std::size_t i = 0; i < dofU; ++i) {
+                        pel.basisFunction(i, phiU, 0);
+                        for (std::size_t j = 0; j < dofP; ++j) {
+                            ret(j, i) =
+                                epsilon * phiU * pel.basisFunctionDeriv(j, 1);
+                        }
+                    }
+                    return ret;
+                });
+        element->setElementMatrix(projectorMatrix, PROJECTOR_MATRIX_ID);
+    }
+}
+
+template <std::size_t DIM>
+void DGMaxDiscretization<DIM>::postProcessElementMatrices(
+    Base::Element* element) const {
+    if (matrixHandling_ == NORMAL) {
+        return;
+    } else if (matrixHandling_ == INVERT) {
+        // Note reference to allow overwriting
+        LinearAlgebra::MiddleSizeMatrix& massMat =
+            element->getElementMatrix(MASS_MATRIX_ID);
+        // Note: Overwrites it.
+        massMat = massMat.inverse();
+    } else if (matrixHandling_ == ORTHOGONALIZE) {
+        // Note reference to allow overwriting
+        LinearAlgebra::MiddleSizeMatrix& massMatrix =
+            element->getElementMatrix(MASS_MATRIX_ID);
+        // Inplace cholesky
+        massMatrix.cholesky();
+
+        // NOTE: All solves happen in place, updating the matrix in place!
+        LinearAlgebra::MiddleSizeMatrix& stiffnessMatrix =
+            element->getElementMatrix(STIFFNESS_MATRIX_ID);
+
+        // Compute L^{-1} S L^{-H}, where S is the stiffness matrix and
+        // LL^H is the mass matrix.
+        massMatrix.solveLowerTriangular(stiffnessMatrix,
+                                        LinearAlgebra::Side::OP_LEFT,
+                                        LinearAlgebra::Transpose::NOT);
+        massMatrix.solveLowerTriangular(
+            stiffnessMatrix, LinearAlgebra::Side::OP_RIGHT,
+            LinearAlgebra::Transpose::HERMITIAN_TRANSPOSE);
+        // Due to rounding errors the matrix might be slightly non
+        // Hermitian, fix this by replacing S by 0.5(S + S^H).
+        for (std::size_t i = 0; i < stiffnessMatrix.getNumberOfRows(); ++i) {
+            stiffnessMatrix(i, i) = std::real(stiffnessMatrix(i, i));
+            for (std::size_t j = i; j < stiffnessMatrix.getNumberOfColumns();
+                 ++j) {
+                std::complex<double> upper =
+                    0.5 *
+                    (stiffnessMatrix(i, j) + std::conj(stiffnessMatrix(j, i)));
+                stiffnessMatrix(i, j) = upper;
+                stiffnessMatrix(j, i) = std::conj(upper);
+            }
+        }
+
+        if (includeProjector_) {
+            LinearAlgebra::MiddleSizeMatrix& projectorMatrix =
+                element->getElementMatrix(PROJECTOR_MATRIX_ID);
+            // Compute B L^{-H}, where B is the projector matrix and L is
+            // the Cholesky factor of the mass matrix.
+            massMatrix.solveLowerTriangular(
+                projectorMatrix, LinearAlgebra::Side::OP_RIGHT,
+                LinearAlgebra::Transpose::HERMITIAN_TRANSPOSE);
         }
     }
 }
@@ -390,54 +326,75 @@ void DGMaxDiscretization<DIM>::elementInnerProduct(
 }
 
 template <std::size_t DIM>
-void DGMaxDiscretization<DIM>::faceMatrix(
-    Base::PhysicalFace<DIM>& fa, LinearAlgebra::MiddleSizeMatrix& ret) const {
-    const Base::Face* face = fa.getFace();
-
-    std::size_t M = face->getPtrElementLeft()->getNrOfBasisFunctions(0);
+void DGMaxDiscretization<DIM>::computeFaceMatrix(Base::Face* face,
+                                                 double stab) {
+    std::size_t numDoFs = face->getNumberOfBasisFunctions(0);
     const bool internalFace = face->isInternal();
-    if (internalFace) {
-        M += face->getPtrElementRight()->getNrOfBasisFunctions(0);
-    }
-    ret.resize(M, M);
-    LinearAlgebra::SmallVector<DIM> phi_i_normal, phi_j_normal, phi_i_curl,
-        phi_j_curl;
-    for (std::size_t i = 0; i < M; ++i) {
-        phi_i_curl = fa.basisFunctionCurl(i, 0);
-        fa.basisFunctionUnitNormalCross(i, phi_i_normal, 0);
+    // Factor for averaging. Negative sign is from the weak formulation
+    double factor = -(internalFace ? 0.5 : 1.);
+    // Standard rescaling of the stability parameter so that it does not need to
+    // depend on the mesh size.
+    stab /= face->getDiameter();
 
-        for (std::size_t j = i; j < M; ++j) {
-            phi_j_curl = fa.basisFunctionCurl(j, 0);
-            fa.basisFunctionUnitNormalCross(j, phi_j_normal, 0);
+    LinearAlgebra::MiddleSizeMatrix stiffnessMatrix =
+        faceIntegrator_.integrate(face, [&](Base::PhysicalFace<DIM>& pfa) {
+            LinearAlgebra::MiddleSizeMatrix ret(numDoFs, numDoFs);
 
-            ret(i, j) = -(internalFace ? 0.5 : 1.) *
-                        (phi_i_normal * phi_j_curl + phi_j_normal * phi_i_curl);
-            ret(j, i) = ret(i, j);
-        }
-    }
+            LinearAlgebra::SmallVector<DIM> phiNi, phiNj, phiCi, phiCj;
+
+            for (std::size_t i = 0; i < numDoFs; ++i) {
+                phiCi = pfa.basisFunctionCurl(i, 0);
+                pfa.basisFunctionUnitNormalCross(i, phiNi, 0);
+
+                for (std::size_t j = i; j < numDoFs; ++j) {
+                    phiCj = pfa.basisFunctionCurl(j, 0);
+                    pfa.basisFunctionUnitNormalCross(j, phiNj, 0);
+                    double value = factor * (phiCi * phiNj + phiNi * phiCj) +
+                                   stab * phiNi * phiNj;
+                    ret(i, j) = value;
+                    if (i != j) {
+                        ret(j, i) = value;
+                    }
+                }
+            }
+
+            return ret;
+        });
+    face->setFaceMatrix(stiffnessMatrix, FACE_MATRIX_ID);
 }
 
 template <std::size_t DIM>
-void DGMaxDiscretization<DIM>::facePenaltyMatrix(
-    Base::PhysicalFace<DIM>& fa, LinearAlgebra::MiddleSizeMatrix& ret,
-    double stab) const {
-    const Base::Face* face = fa.getFace();
-    double diameter = face->getDiameter();
+void DGMaxDiscretization<DIM>::postProcessFaceMatrices(Base::Face* face) const {
+    if (matrixHandling_ == ORTHOGONALIZE) {
+        // A reference to the matrix that will be updated in place.
+        Base::FaceMatrix& faceMatrix = face->getFaceMatrix(FACE_MATRIX_ID);
 
-    std::size_t M = face->getPtrElementLeft()->getNrOfBasisFunctions(0);
-    if (face->isInternal()) {
-        M += face->getPtrElementRight()->getNrOfBasisFunctions(0);
-    }
-
-    ret.resize(M, M);
-    LinearAlgebra::SmallVector<DIM> phi_i, phi_j;
-    for (std::size_t i = 0; i < M; ++i) {
-        fa.basisFunctionUnitNormalCross(i, phi_i, 0);
-        for (std::size_t j = i; j < M; ++j) {
-            fa.basisFunctionUnitNormalCross(j, phi_j, 0);
-
-            ret(i, j) = stab / diameter * (phi_i * phi_j);
-            ret(j, i) = ret(i, j);
+        bool isInternal = face->isInternal();
+        std::size_t sideCount = isInternal ? 2 : 1;
+        // The mass matrix/matrices that form a block diagonal matrix
+        std::array<LinearAlgebra::MiddleSizeMatrix*, 2> massMatrices = {
+            nullptr, nullptr};
+        massMatrices[0] =
+            &face->getPtrElementLeft()->getElementMatrix(MASS_MATRIX_ID);
+        std::array<hpgem::Base::Side, 2> sides = {Base::Side::LEFT,
+                                                  Base::Side::RIGHT};
+        if (isInternal) {
+            massMatrices[1] =
+                &face->getPtrElementRight()->getElementMatrix(MASS_MATRIX_ID);
+        }
+        for (std::size_t i = 0; i < sideCount; ++i) {
+            for (std::size_t j = 0; j < sideCount; ++j) {
+                LinearAlgebra::MiddleSizeMatrix& subMatrix =
+                    faceMatrix.getElementMatrix(sides[i], sides[j]);
+                // Rescale the submatrix, note that different mass matrices may
+                // be used for the left and right side.
+                massMatrices[i]->solveLowerTriangular(
+                    subMatrix, hpgem::LinearAlgebra::Side::OP_LEFT,
+                    hpgem::LinearAlgebra::Transpose::NOT);
+                massMatrices[j]->solveLowerTriangular(
+                    subMatrix, LinearAlgebra::Side::OP_RIGHT,
+                    LinearAlgebra::Transpose::HERMITIAN_TRANSPOSE);
+            }
         }
     }
 }
@@ -537,16 +494,11 @@ std::map<typename DGMaxDiscretization<DIM>::NormType, double>
         Base::MeshManipulator<DIM>& mesh, std::size_t timeVector,
         DGMaxDiscretization<DIM>::InputFunction electricField,
         DGMaxDiscretization<DIM>::InputFunction electricFieldCurl,
-        std::set<DGMaxDiscretization<DIM>::NormType> norms) const {
+        std::set<DGMaxDiscretization<DIM>::NormType> norms) {
     // Note these are actually the squared norms
     double l2Norm = 0;
     double hCurlNorm = 0;
     // Setup the element integration.
-    Integration::ElementIntegral<DIM> elIntegral;
-    elIntegral.setTransformation(
-        std::shared_ptr<Base::CoordinateTransformation<DIM>>(
-            new Base::HCurlConformingTransformation<DIM>()));
-
     bool l2Wanted = norms.find(NormType::L2) != norms.end();
     bool hcurlWanted = norms.find(NormType::HCurl) != norms.end();
     bool dgWanted = norms.find(NormType::DG) != norms.end();
@@ -555,8 +507,8 @@ std::map<typename DGMaxDiscretization<DIM>::NormType, double>
     for (typename Base::MeshManipulator<DIM>::ElementIterator it =
              mesh.elementColBegin();
          it != end; ++it) {
-        LinearAlgebra::SmallVector<2> errors =
-            elIntegral.integrate((*it), [&](Base::PhysicalElement<DIM>& el) {
+        LinearAlgebra::SmallVector<2> errors = elementIntegrator_.integrate(
+            (*it), [&](Base::PhysicalElement<DIM>& el) {
                 return elementErrorIntegrand(el, dgWanted || hcurlWanted,
                                              timeVector, electricField,
                                              electricFieldCurl);
@@ -570,15 +522,12 @@ std::map<typename DGMaxDiscretization<DIM>::NormType, double>
 
     if (dgWanted) {
         Integration::FaceIntegral<DIM> faIntegral;
-        faIntegral.setTransformation(
-            std::shared_ptr<Base::CoordinateTransformation<DIM>>(
-                new Base::HCurlConformingTransformation<DIM>()));
         auto end = mesh.faceColEnd();
         for (typename Base::MeshManipulator<DIM>::FaceIterator it =
                  mesh.faceColBegin();
              it != end; ++it) {
-            dgNorm +=
-                faIntegral.integrate(*it, [&](Base::PhysicalFace<DIM>& face) {
+            dgNorm += faceIntegrator_.integrate(
+                *it, [&](Base::PhysicalFace<DIM>& face) {
                     return faceErrorIntegrand(face, timeVector, electricField);
                 });
         }

--- a/applications/DG-Max/Algorithms/DGMaxDiscretization.h
+++ b/applications/DG-Max/Algorithms/DGMaxDiscretization.h
@@ -35,6 +35,8 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
+#ifndef HPGEM_APP_DGMAXDISCRETIZATION_H
+#define HPGEM_APP_DGMAXDISCRETIZATION_H
 
 #include <functional>
 #include <map>
@@ -42,43 +44,23 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <set>
 
 #include "Logger.h"
-
-#ifndef HPGEM_APP_DGMAXDISCRETIZATION_H
-#define HPGEM_APP_DGMAXDISCRETIZATION_H
-
-// Forward definitions
-namespace hpgem {
-namespace Base {
-class Element;
-template <std::size_t>
-class MeshManipulator;
-template <std::size_t DIM>
-class PhysicalElement;
-template <std::size_t DIM>
-class PhysicalFace;
-}  // namespace Base
-
-namespace LinearAlgebra {
-class MiddleSizeMatrix;
-class MiddleSizeVector;
-
-template <std::size_t DIM>
-class SmallVector;
-}  // namespace LinearAlgebra
-
-namespace Geometry {
-template <std::size_t DIM>
-class PointReference;
-template <std::size_t DIM>
-class PointPhysical;
-}  // namespace Geometry
-}  // namespace hpgem
+#include "Base/Element.h"
+#include "Base/Face.h"
+#include "Base/PhysicalElement.h"
+#include "Base/PhysicalFace.h"
+#include "Base/MeshManipulator.h"
+#include "Geometry/PointPhysical.h"
+#include "Integration/ElementIntegral.h"
+#include "Integration/FaceIntegral.h"
 
 using namespace hpgem;
 
 /// Dimension independent constants of DGMaxDiscretization
 class DGMaxDiscretizationBase {
    public:
+    /**
+     * Processed mass matrix, contents depends on the rescaling approach.
+     */
     static const std::size_t MASS_MATRIX_ID = 0;
     static const std::size_t STIFFNESS_MATRIX_ID = 1;
     static const std::size_t PROJECTOR_MATRIX_ID = 2;
@@ -91,15 +73,32 @@ class DGMaxDiscretizationBase {
 
     enum NormType { L2, HCurl, DG };
 
+    /**
+     * Several options for how matrices are rescaled to aid the using algorithm.
+     */
     enum MassMatrixHandling {
-        /// Compute the mass matrix
+        /**
+         * Compute the mass matrix, no extra steps
+         */
         NORMAL,
-        /// Compute the inverse of the mass matrix
+        /**
+         * Compute the inverse of the mass matrix and store it as
+         * MASS_MATRIX_ID.
+         */
         INVERT,
-        /// Compute the Cholesky decomposition LL^H = M of the mass matrix and
-        /// use this to rescale the stiffness matrix and mass matrix.
-        /// Effectively this is an orthogonalization of the basis functions with
-        /// respect to the innerproduct defined by the mass matrix.
+        /**
+         * Symmetrically rescale the matrices. The effect is the same as if the
+         * basis functions were orthonormalized with respect to the L2-epsilon
+         * inner product.
+         *
+         * The mass matrix M is factored as LL^H = M. The following
+         * transformations are done:
+         *  - Instead of the mass matrix its factor L is stored
+         *  - The stiffness matrix S is rescaled to L^{-1} S L^{-H}
+         *  - The projector B is rescaled to B L^{-H}
+         *  - Any resulting vector y needs to be unscaled y = L^H x, to obtain
+         * basis function coefficients x.
+         */
         ORTHOGONALIZE
     };
 };
@@ -107,7 +106,7 @@ class DGMaxDiscretizationBase {
 template <std::size_t DIM>
 class DGMaxDiscretization : public DGMaxDiscretizationBase {
    public:
-    using PointPhysicalT = Geometry::PointPhysical<DIM>;
+    using PointPhysicalT = hpgem::Geometry::PointPhysical<DIM>;
     using InputFunction =
         std::function<LinearAlgebra::SmallVector<DIM>(const PointPhysicalT&)>;
     using FaceInputFunction = std::function<LinearAlgebra::SmallVector<DIM>(
@@ -123,8 +122,11 @@ class DGMaxDiscretization : public DGMaxDiscretizationBase {
         LinearAlgebra::SmallVector<DIM> imagEField;
     };
 
-    DGMaxDiscretization(bool includeProjector = false)
-        : includeProjector_(includeProjector) {}
+    DGMaxDiscretization(bool includeProjector = false);
+
+    void setMatrixHandling(MassMatrixHandling matrixHandling) {
+        matrixHandling_ = matrixHandling;
+    }
 
     void initializeBasisFunctions(Base::MeshManipulator<DIM>& mesh,
                                   std::size_t order);
@@ -137,12 +139,12 @@ class DGMaxDiscretization : public DGMaxDiscretizationBase {
      * to the function to use.
      */
     void computeElementIntegrands(
-        Base::MeshManipulator<DIM>& mesh, MassMatrixHandling massMatrix,
-        const std::map<std::size_t, InputFunction>& elementVectors) const;
+        Base::MeshManipulator<DIM>& mesh,
+        const std::map<std::size_t, InputFunction>& elementVectors);
     void computeFaceIntegrals(
-        Base::MeshManipulator<DIM>& mesh, MassMatrixHandling massMatrix,
+        Base::MeshManipulator<DIM>& mesh,
         const std::map<std::size_t, FaceInputFunction>& boundaryVectors,
-        double stab) const;
+        double stab);
 
     static std::string normName(NormType norm) {
         switch (norm) {
@@ -162,7 +164,7 @@ class DGMaxDiscretization : public DGMaxDiscretizationBase {
                                             std::size_t timeVector,
                                             InputFunction electricField,
                                             InputFunction electricFieldCurl,
-                                            std::set<NormType> norms) const;
+                                            std::set<NormType> norms);
 
     Fields computeFields(
         const Base::Element* element, const Geometry::PointReference<DIM>& p,
@@ -175,28 +177,23 @@ class DGMaxDiscretization : public DGMaxDiscretizationBase {
         const LinearAlgebra::MiddleSizeVector& coefficients) const;
 
    private:
-    // Mass matrix of the element
-    void elementMassMatrix(Base::PhysicalElement<DIM>& el,
-                           LinearAlgebra::MiddleSizeMatrix& ret) const;
-    // Stiffness matrix, TODO: Is this the real stiffness or is this more
-    // something like curl-stiffness?
-    void elementStiffnessMatrix(Base::PhysicalElement<DIM>& el,
-                                LinearAlgebra::MiddleSizeMatrix& ret) const;
-    void elementProjectorMatrix(Base::PhysicalElement<DIM>& el,
-                                LinearAlgebra::MiddleSizeMatrix& ret) const;
+    /**
+     * Compute the element local matrices
+     */
+    void computeElementMatrices(Base::Element* element);
+    /**
+     * Post process the element local matrices based on matrixHandling_
+     */
+    void postProcessElementMatrices(Base::Element* element) const;
+
     // Element vector integrand for the source term
     void elementInnerProduct(Base::PhysicalElement<DIM>& el,
                              const InputFunction& function,
                              LinearAlgebra::MiddleSizeVector& ret) const;
 
-    // TODO: when this code can be tested, merge the two functions
-    // The 'standard part' in the face matrix (jump-avg + avg-jump)
-    void faceMatrix(Base::PhysicalFace<DIM>& fa,
-                    LinearAlgebra::MiddleSizeMatrix& ret) const;
-    // The penalty term in the face matrix
-    void facePenaltyMatrix(Base::PhysicalFace<DIM>& fa,
-                           LinearAlgebra::MiddleSizeMatrix& ret,
-                           double stab) const;
+    void computeFaceMatrix(Base::Face* face, double stab);
+    void postProcessFaceMatrices(Base::Face* face) const;
+
     // The face vector integrand.
     void faceVector(Base::PhysicalFace<DIM>& fa,
                     const FaceInputFunction& boundaryCondition,
@@ -212,6 +209,12 @@ class DGMaxDiscretization : public DGMaxDiscretizationBase {
                               InputFunction exactValue) const;
 
     const bool includeProjector_;
+    MassMatrixHandling matrixHandling_;
+
+    std::vector<std::shared_ptr<Base::CoordinateTransformation<DIM>>>
+        transforms_;
+    Integration::ElementIntegral<DIM> elementIntegrator_;
+    Integration::FaceIntegral<DIM> faceIntegrator_;
 };
 
 #endif  // HPGEM_APP_DGMAXDISCRETIZATION_H

--- a/applications/DG-Max/Algorithms/DGMaxEigenvalue.cpp
+++ b/applications/DG-Max/Algorithms/DGMaxEigenvalue.cpp
@@ -78,13 +78,12 @@ void DGMaxEigenvalue<DIM>::initializeMatrices() {
     // No element vectors
     std::map<std::size_t, typename DGMaxDiscretization<DIM>::InputFunction>
         elementVectors;
-    discretization_.computeElementIntegrands(mesh_, massMatrixHandling,
-                                             elementVectors);
+    discretization_.setMatrixHandling(massMatrixHandling);
+    discretization_.computeElementIntegrands(mesh_, elementVectors);
     // No face vectors
     std::map<std::size_t, typename DGMaxDiscretization<DIM>::FaceInputFunction>
         faceVectors;
-    discretization_.computeFaceIntegrals(mesh_, massMatrixHandling, faceVectors,
-                                         config_.stab_);
+    discretization_.computeFaceIntegrals(mesh_, faceVectors, config_.stab_);
 }
 
 // SolverWorkspace //
@@ -473,7 +472,7 @@ void DGMaxEigenvalue<DIM>::SolverWorkspace::initStiffnessShellMatrix() {
                            PETSC_DETERMINE, this, &shell_);
     CHKERRABORT(PETSC_COMM_WORLD, error);
     error = MatShellSetOperation(shell_, MATOP_MULT,
-                                 (void (*)(void))staticShellMultiply);
+                                 (void(*)(void))staticShellMultiply);
     CHKERRABORT(PETSC_COMM_WORLD, error);
 }
 

--- a/applications/DG-Max/Algorithms/DGMaxEigenvalue.cpp
+++ b/applications/DG-Max/Algorithms/DGMaxEigenvalue.cpp
@@ -472,7 +472,7 @@ void DGMaxEigenvalue<DIM>::SolverWorkspace::initStiffnessShellMatrix() {
                            PETSC_DETERMINE, this, &shell_);
     CHKERRABORT(PETSC_COMM_WORLD, error);
     error = MatShellSetOperation(shell_, MATOP_MULT,
-                                 (void(*)(void))staticShellMultiply);
+                                 (void (*)(void))staticShellMultiply);
     CHKERRABORT(PETSC_COMM_WORLD, error);
 }
 

--- a/applications/DG-Max/Algorithms/DGMaxHarmonic.cpp
+++ b/applications/DG-Max/Algorithms/DGMaxHarmonic.cpp
@@ -65,8 +65,8 @@ void DGMaxHarmonic<DIM>::solve(const HarmonicProblem<DIM>& harmonicProblem) {
         std::bind(&HarmonicProblem<DIM>::sourceTerm, std::ref(harmonicProblem),
                   std::placeholders::_1);
 
-    discretization.computeElementIntegrands(
-        mesh_, DGMaxDiscretizationBase::NORMAL, elementVectors);
+    discretization.setMatrixHandling(DGMaxDiscretizationBase::NORMAL);
+    discretization.computeElementIntegrands(mesh_, elementVectors);
 
     std::map<std::size_t, typename DGMaxDiscretization<DIM>::FaceInputFunction>
         faceVectors;
@@ -74,8 +74,7 @@ void DGMaxHarmonic<DIM>::solve(const HarmonicProblem<DIM>& harmonicProblem) {
         std::bind(&HarmonicProblem<DIM>::boundaryCondition,
                   std::ref(harmonicProblem), std::placeholders::_1);
 
-    discretization.computeFaceIntegrals(mesh_, DGMaxDiscretizationBase::NORMAL,
-                                        faceVectors, stab_);
+    discretization.computeFaceIntegrals(mesh_, faceVectors, stab_);
 
     Utilities::GlobalIndexing indexing(&mesh_);
     Utilities::GlobalPetscMatrix massMatrix(
@@ -151,7 +150,7 @@ std::map<typename DGMaxDiscretization<DIM>::NormType, double>
         const std::set<typename DGMaxDiscretization<DIM>::NormType>& norms,
         const typename DGMaxDiscretization<DIM>::InputFunction& exactSolution,
         const typename DGMaxDiscretization<DIM>::InputFunction&
-            exactSolutionCurl) const {
+            exactSolutionCurl) {
     // Note, this only works by grace of distributing the solution as
     // timeIntegrationVector
     return discretization.computeError(mesh_,
@@ -163,7 +162,7 @@ template <std::size_t DIM>
 std::map<typename DGMaxDiscretization<DIM>::NormType, double>
     DGMaxHarmonic<DIM>::computeError(
         const std::set<typename DGMaxDiscretization<DIM>::NormType>& norms,
-        const ExactHarmonicProblem<DIM>& problem) const {
+        const ExactHarmonicProblem<DIM>& problem) {
     return computeError(norms,
                         std::bind(&ExactHarmonicProblem<DIM>::exactSolution,
                                   std::ref(problem), std::placeholders::_1),

--- a/applications/DG-Max/Algorithms/DGMaxHarmonic.h
+++ b/applications/DG-Max/Algorithms/DGMaxHarmonic.h
@@ -59,11 +59,11 @@ class DGMaxHarmonic : public DGMax::AbstractHarmonicSolver<DIM> {
             norms,
         const typename DGMaxDiscretization<DIM>::InputFunction& exactSolution,
         const typename DGMaxDiscretization<DIM>::InputFunction&
-            exactSolutionCurl) const;
+            exactSolutionCurl);
 
     std::map<typename DGMaxDiscretization<DIM>::NormType, double> computeError(
         const std::set<typename DGMaxDiscretization<DIM>::NormType>& norms,
-        const ExactHarmonicProblem<DIM>& problem) const;
+        const ExactHarmonicProblem<DIM>& problem);
 
     void writeTec(std::string fileName) const;
     void writeVTK(Output::VTKSpecificTimeWriter<DIM>& output) const final;

--- a/applications/DG-Max/Algorithms/DGMaxTimeIntegration.cpp
+++ b/applications/DG-Max/Algorithms/DGMaxTimeIntegration.cpp
@@ -95,8 +95,8 @@ void DGMaxTimeIntegration<DIM>::solve(
             std::bind(&TimeIntegrationProblem<DIM>::initialConditionDerivative,
                       std::ref(input), _1);
 
-    discretization.computeElementIntegrands(
-        mesh_, DGMaxDiscretizationBase::INVERT, elementVectors);
+    discretization.setMatrixHandling(DGMaxDiscretizationBase::INVERT);
+    discretization.computeElementIntegrands(mesh_, elementVectors);
 
     std::map<std::size_t, typename DGMaxDiscretization<DIM>::FaceInputFunction>
         faceVectors;
@@ -104,8 +104,7 @@ void DGMaxTimeIntegration<DIM>::solve(
         std::bind(&SeparableTimeIntegrationProblem<DIM>::boundaryConditionRef,
                   std::ref(input), _1);
 
-    discretization.computeFaceIntegrals(mesh_, DGMaxDiscretizationBase::INVERT,
-                                        faceVectors, parameters.stab);
+    discretization.computeFaceIntegrals(mesh_, faceVectors, parameters.stab);
     //    MHasToBeInverted_ = true;
     //    assembler->fillMatrices(this);
 
@@ -379,7 +378,7 @@ template <std::size_t DIM>
 void DGMaxTimeIntegration<DIM>::printErrors(
     const std::vector<typename DGMaxDiscretization<DIM>::NormType>& norms,
     const typename DGMaxDiscretization<DIM>::TimeFunction& exactField,
-    const typename DGMaxDiscretization<DIM>::TimeFunction& exactCurl) const {
+    const typename DGMaxDiscretization<DIM>::TimeFunction& exactCurl) {
     using NormType = typename DGMaxDiscretization<DIM>::NormType;
     std::set<NormType> normSet;
 
@@ -406,7 +405,7 @@ void DGMaxTimeIntegration<DIM>::printErrors(
 template <std::size_t DIM>
 void DGMaxTimeIntegration<DIM>::printErrors(
     const std::vector<typename DGMaxDiscretization<DIM>::NormType>& norms,
-    const ExactTimeIntegrationProblem<DIM>& problem) const {
+    const ExactTimeIntegrationProblem<DIM>& problem) {
     printErrors(norms,
                 std::bind(&ExactTimeIntegrationProblem<DIM>::exactSolution,
                           std::ref(problem), std::placeholders::_1,

--- a/applications/DG-Max/Algorithms/DGMaxTimeIntegration.h
+++ b/applications/DG-Max/Algorithms/DGMaxTimeIntegration.h
@@ -66,10 +66,10 @@ class DGMaxTimeIntegration {
     void printErrors(
         const std::vector<typename DGMaxDiscretization<DIM>::NormType>& norms,
         const typename DGMaxDiscretization<DIM>::TimeFunction& exactField,
-        const typename DGMaxDiscretization<DIM>::TimeFunction& exactCurl) const;
+        const typename DGMaxDiscretization<DIM>::TimeFunction& exactCurl);
     void printErrors(
         const std::vector<typename DGMaxDiscretization<DIM>::NormType>& norms,
-        const ExactTimeIntegrationProblem<DIM>& problem) const;
+        const ExactTimeIntegrationProblem<DIM>& problem);
 
    private:
     /// \brief Coefficients for the CO4 algorithm.

--- a/kernel/Base/FaceData.cpp
+++ b/kernel/Base/FaceData.cpp
@@ -121,6 +121,14 @@ LinearAlgebra::MiddleSizeMatrix Base::FaceData::getFaceMatrixMatrix(
     return faceMatrix_[matrixID].getEntireMatrix();
 }
 
+Base::FaceMatrix& Base::FaceData::getFaceMatrix(std::size_t matrixID) {
+    // Check if there are enough faces matrices stored.
+    logger.assert_debug(matrixID < faceMatrix_.size(),
+                        "Not enough face matrices stored.");
+
+    return faceMatrix_[matrixID];
+}
+
 /// \param[in] matrixID The index to specify which FaceMatrix to get.
 const Base::FaceMatrix& Base::FaceData::getFaceMatrix(
     std::size_t matrixID) const {

--- a/kernel/Base/FaceData.h
+++ b/kernel/Base/FaceData.h
@@ -81,7 +81,6 @@ class FaceData {
     LinearAlgebra::MiddleSizeMatrix getFaceMatrixMatrix(
         std::size_t matrixID = 0) const;
 
-
     FaceMatrix& getFaceMatrix(std::size_t matrixID);
 
     /// \brief Returns face matrix number 'matrixID'.

--- a/kernel/Base/FaceData.h
+++ b/kernel/Base/FaceData.h
@@ -81,6 +81,9 @@ class FaceData {
     LinearAlgebra::MiddleSizeMatrix getFaceMatrixMatrix(
         std::size_t matrixID = 0) const;
 
+
+    FaceMatrix& getFaceMatrix(std::size_t matrixID);
+
     /// \brief Returns face matrix number 'matrixID'.
     const FaceMatrix& getFaceMatrix(std::size_t matrixID = 0) const;
 

--- a/kernel/Base/FaceMatrix.cpp
+++ b/kernel/Base/FaceMatrix.cpp
@@ -182,6 +182,22 @@ const LinearAlgebra::MiddleSizeMatrix &FaceMatrix::getElementMatrix(
     }
 }
 
+LinearAlgebra::MiddleSizeMatrix &FaceMatrix::getElementMatrix(Side iSide,
+                                                              Side jSide) {
+    if (iSide == Side::LEFT) {
+        if (jSide == Side::LEFT) {
+            return M_LeftLeft_;
+        }
+        return M_LeftRight_;
+
+    } else {
+        if (jSide == Side::LEFT) {
+            return M_RightLeft_;
+        }
+        return M_RightRight_;
+    }
+}
+
 /// \param[in] elementMatrix The matrix used to set the element matrix
 /// corresponding to sides iSide and jSide. \param[in] iSide Side of the
 /// adjacent element to consider the test function. \param[in] jSide Side of the

--- a/kernel/Base/FaceMatrix.h
+++ b/kernel/Base/FaceMatrix.h
@@ -111,6 +111,7 @@ class FaceMatrix {
     /// combination of two elements connected to the face.
     const LinearAlgebra::MiddleSizeMatrix &getElementMatrix(Side iSide,
                                                             Side jSide) const;
+    LinearAlgebra::MiddleSizeMatrix &getElementMatrix(Side iSide, Side jSide);
 
     /// \brief Sets the submatrix corresponding to a combination of two elements
     /// connected to the face.


### PR DESCRIPTION
The primary step of this refactoring is to take the complicated matrix assembly step and restructure it. The original  implementation had a loop over the elements/faces that did several things:
 - Run the integrator
 - Delegate the integrand to a function
 - Postprocess the resulting matrix/matrices for the mass matrix
 - Store the matrices as element/face matrix
 - [not modified] Compute element/face vectors

This refactoring unclutters this process to only two function calls:
 1. Call a function to compute the face/element matrices
 2. Call a function to post process the matrices

The first function does the integration for each type of matrix and stores them in the element/face. The second one takes the matrix and the and post processes them as required. I decided to keep them in this fashion, as this would give the posibility of optimizing the element/face integrals at some point.