### PR TITLE
Fix the source function in DivDGMax

### DIFF
--- a/applications/DG-Max/Algorithms/DivDGMaxDiscretization.cpp
+++ b/applications/DG-Max/Algorithms/DivDGMaxDiscretization.cpp
@@ -391,15 +391,12 @@ void DivDGMaxDiscretization<DIM>::elementSourceVector(
     Base::PhysicalElement<DIM>& el, const InputFunction& source,
     LinearAlgebra::MiddleSizeVector& ret) const {
     const Base::Element* element = el.getElement();
-    const Geometry::PointReference<DIM>& p = el.getPointReference();
     std::size_t uDoFs = element->getNumberOfBasisFunctions(0);
     std::size_t pDoFs = element->getNumberOfBasisFunctions(1);
     ret.resize(uDoFs + pDoFs);
 
-    PointPhysicalT pPhys;
-    pPhys = element->referenceToPhysical(p);
     LinearAlgebra::SmallVector<DIM> sourceValue, phi;
-    source(pPhys, sourceValue);
+    sourceValue = source(el.getPointPhysical());
     for (std::size_t i = 0; i < (uDoFs); ++i) {
         el.basisFunction(i, phi, 0);
         ret(i) = phi * sourceValue;
@@ -1244,7 +1241,6 @@ double DivDGMaxDiscretization<DIM>::elementErrorIntegrand(
     Base::PhysicalElement<DIM>& el, std::size_t timeVector,
     const DivDGMaxDiscretization<DIM>::InputFunction& exactValues) const {
     const Base::Element* element = el.getElement();
-    const Geometry::PointPhysical<DIM>& pPhys = el.getPointPhysical();
 
     std::size_t numberOfUDoFs = element->getNumberOfBasisFunctions(0),
                 numberOfPDoFs = element->getNumberOfBasisFunctions(1);
@@ -1252,7 +1248,7 @@ double DivDGMaxDiscretization<DIM>::elementErrorIntegrand(
         element->getTimeIntegrationVector(timeVector);
 
     LinearAlgebra::SmallVector<DIM> error, phi;
-    exactValues(pPhys, error);
+    error = exactValues(el.getPointPhysical());
     for (std::size_t i = 0; i < numberOfUDoFs; ++i) {
         el.basisFunction(i, phi, 0);
         error -= std::real(data[i]) * phi;

--- a/applications/DG-Max/Algorithms/DivDGMaxDiscretization.h
+++ b/applications/DG-Max/Algorithms/DivDGMaxDiscretization.h
@@ -128,8 +128,8 @@ class DivDGMaxDiscretization {
 
     // See notes in DGMaxDiscretization
     using PointPhysicalT = Geometry::PointPhysical<DIM>;
-    using InputFunction = std::function<void(const PointPhysicalT&,
-                                             LinearAlgebra::SmallVector<DIM>&)>;
+    using InputFunction =
+        std::function<LinearAlgebra::SmallVector<DIM>(const PointPhysicalT&)>;
     using FaceInputFunction = std::function<LinearAlgebra::SmallVector<DIM>(
         Base::PhysicalFace<DIM>&)>;
 


### PR DESCRIPTION
The cause is that the constructor to std::function allows very general types. So general that type checking becomes almost powerless.

Some unit tests for (Div)DGMax will follow separately.