### PR TITLE
Cleanup divdgmax discretization

### DIFF
--- a/applications/DG-Max/Algorithms/DivDGMaxDiscretization.cpp
+++ b/applications/DG-Max/Algorithms/DivDGMaxDiscretization.cpp
@@ -47,6 +47,13 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 using namespace hpgem;
 
+// Definition of the constants to reference to.
+const std::size_t DivDGMaxDiscretizationBase::ELEMENT_MASS_MATRIX_ID;
+const std::size_t DivDGMaxDiscretizationBase::ELEMENT_STIFFNESS_MATRIX_ID;
+const std::size_t DivDGMaxDiscretizationBase::ELEMENT_SOURCE_VECTOR_ID;
+const std::size_t DivDGMaxDiscretizationBase::FACE_STIFFNESS_MATRIX_ID;
+const std::size_t DivDGMaxDiscretizationBase::FACE_BOUNDARY_VECTOR_ID;
+
 // Utility function
 struct FaceDoFInfo {
     std::size_t leftUDoFs;
@@ -1261,12 +1268,11 @@ double DivDGMaxDiscretization<DIM>::elementErrorIntegrand(
     return error.l2NormSquared();
 }
 
-template <std::size_t DIM>
-char fluxName(typename DivDGMaxDiscretization<DIM>::FluxType f) {
+char fluxName(typename DivDGMaxDiscretizationBase::FluxType f) {
     switch (f) {
-        case DivDGMaxDiscretization<DIM>::FluxType::BREZZI:
+        case DivDGMaxDiscretizationBase::FluxType::BREZZI:
             return 'b';
-        case DivDGMaxDiscretization<DIM>::FluxType::IP:
+        case DivDGMaxDiscretizationBase::FluxType::IP:
             return 'i';
         default:
             logger.assert_always(false, "Unknown flux type.");
@@ -1274,22 +1280,12 @@ char fluxName(typename DivDGMaxDiscretization<DIM>::FluxType f) {
     }
 }
 
-template <std::size_t DIM>
-std::ostream& printStab(
-    std::ostream& os, const typename DivDGMaxDiscretization<DIM>::Stab& stab) {
-    os << "Stab{" << fluxName<DIM>(stab.fluxType1) << "=" << stab.stab1 << ", "
-       << fluxName<DIM>(stab.fluxType2) << "=" << stab.stab2 << ", "
-       << fluxName<DIM>(stab.fluxType3) << "=" << stab.stab3 << "}";
+std::ostream& operator<<(
+    std::ostream& os, const DivDGMaxDiscretizationBase::Stab& stab) {
+    os << "Stab{" << fluxName(stab.fluxType1) << "=" << stab.stab1 << ", "
+       << fluxName(stab.fluxType2) << "=" << stab.stab2 << ", "
+       << fluxName(stab.fluxType3) << "=" << stab.stab3 << "}";
     return os;
-}
-
-std::ostream& operator<<(std::ostream& os,
-                         typename DivDGMaxDiscretization<2>::Stab& stab) {
-    return printStab<2>(os, stab);
-}
-std::ostream& operator<<(std::ostream& os,
-                         typename DivDGMaxDiscretization<3>::Stab& stab) {
-    return printStab<3>(os, stab);
 }
 
 template class DivDGMaxDiscretization<2>;

--- a/applications/DG-Max/Algorithms/DivDGMaxDiscretization.cpp
+++ b/applications/DG-Max/Algorithms/DivDGMaxDiscretization.cpp
@@ -141,7 +141,7 @@ void DivDGMaxDiscretization<DIM>::initializeBasisFunctions(
 
 template <std::size_t DIM>
 void DivDGMaxDiscretization<DIM>::computeElementIntegrands(
-    Base::MeshManipulator<DIM>& mesh, bool invertMassMatrix,
+    Base::MeshManipulator<DIM>& mesh,
     const std::map<std::size_t, InputFunction>& elementVectors) {
 
     Utilities::ElementLocalIndexing indexing;
@@ -153,13 +153,6 @@ void DivDGMaxDiscretization<DIM>::computeElementIntegrands(
         Base::Element* element = *it;
         indexing.reinit(element);
         computeElementMatrices(element, indexing);
-
-        if (invertMassMatrix) {
-            // Note reference to allow overwriting it
-            LinearAlgebra::MiddleSizeMatrix& massMatrix =
-                element->getElementMatrix(ELEMENT_MASS_MATRIX_ID);
-            massMatrix = massMatrix.inverse();
-        }
 
         for (const auto& elementVec : elementVectors) {
             LinearAlgebra::MiddleSizeVector vec;

--- a/applications/DG-Max/Algorithms/DivDGMaxDiscretization.cpp
+++ b/applications/DG-Max/Algorithms/DivDGMaxDiscretization.cpp
@@ -199,8 +199,8 @@ void DivDGMaxDiscretization<DIM>::computeFaceIntegrals(
         faceMatrix = faceIntegrator_.integrate(
             face, [&indexing, &stab, this](Base::PhysicalFace<DIM>& face) {
                 LinearAlgebra::MiddleSizeMatrix result, temp;
-                faceStiffnessMatrix1(face, indexing, stab, result);
-                addScalarFaceMatrixTerms(face, indexing, stab, result);
+                faceStiffnessMatrixFieldIntegrand(face, indexing, stab, result);
+                addFaceMatrixPotentialIntegrand(face, indexing, stab, result);
                 return result;
             });
 
@@ -392,7 +392,7 @@ void DivDGMaxDiscretization<DIM>::elementSourceVector(
 }
 
 template <std::size_t DIM>
-void DivDGMaxDiscretization<DIM>::faceStiffnessMatrix1(
+void DivDGMaxDiscretization<DIM>::faceStiffnessMatrixFieldIntegrand(
     Base::PhysicalFace<DIM>& fa, const Utilities::FaceLocalIndexing& indexing,
     const Stab& stab, LinearAlgebra::MiddleSizeMatrix& ret) const {
 
@@ -480,7 +480,7 @@ void DivDGMaxDiscretization<DIM>::faceStiffnessMatrix1(
 }
 
 template <std::size_t DIM>
-void DivDGMaxDiscretization<DIM>::addScalarFaceMatrixTerms(
+void DivDGMaxDiscretization<DIM>::addFaceMatrixPotentialIntegrand(
     Base::PhysicalFace<DIM>& fa, const Utilities::FaceLocalIndexing& indexing,
     const Stab& stab, LinearAlgebra::MiddleSizeMatrix& ret) const {
 

--- a/applications/DG-Max/Algorithms/DivDGMaxDiscretization.cpp
+++ b/applications/DG-Max/Algorithms/DivDGMaxDiscretization.cpp
@@ -38,10 +38,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "DivDGMaxDiscretization.h"
 
-#include "Base/MeshManipulator.h"
-#include "Base/HCurlConformingTransformation.h"
-#include "Integration/ElementIntegral.h"
-#include "Integration/FaceIntegral.h"
+#include "Utilities/ElementLocalIndexing.h"
+#include "Utilities/FaceLocalIndexing.h"
 
 #include "ElementInfos.h"
 

--- a/applications/DG-Max/Algorithms/DivDGMaxDiscretization.cpp
+++ b/applications/DG-Max/Algorithms/DivDGMaxDiscretization.cpp
@@ -147,10 +147,9 @@ void DivDGMaxDiscretization<DIM>::computeElementIntegrands(
     Utilities::ElementLocalIndexing indexing;
     indexing.reinit({0, 1});
 
+    // Out of efficiency, elementColEnd may be expensive
     auto end = mesh.elementColEnd();
-    for (typename Base::MeshManipulator<DIM>::ElementIterator it =
-             mesh.elementColBegin();
-         it != end; ++it) {
+    for (auto it = mesh.elementColBegin(); it != end; ++it) {
         Base::Element* element = *it;
         indexing.reinit(element);
         computeElementMatrices(element, indexing);
@@ -189,6 +188,7 @@ void DivDGMaxDiscretization<DIM>::computeFaceIntegrals(
     Utilities::FaceLocalIndexing indexing;
     indexing.reinit({0, 1});
 
+    // For efficiency, faceColEnd may be expensive
     auto end = mesh.faceColEnd();
     for (auto it = mesh.faceColBegin(); it != end; ++it) {
 

--- a/applications/DG-Max/Algorithms/DivDGMaxDiscretization.cpp
+++ b/applications/DG-Max/Algorithms/DivDGMaxDiscretization.cpp
@@ -52,6 +52,35 @@ const std::size_t DivDGMaxDiscretizationBase::ELEMENT_SOURCE_VECTOR_ID;
 const std::size_t DivDGMaxDiscretizationBase::FACE_STIFFNESS_MATRIX_ID;
 const std::size_t DivDGMaxDiscretizationBase::FACE_BOUNDARY_VECTOR_ID;
 
+/// Helper struct to access the material information in elements adjacent to a
+/// face.
+struct FaceMaterialInfo {
+    template <std::size_t DIM>
+    FaceMaterialInfo(Base::PhysicalFace<DIM>& fa) {
+        const Base::Face* face = fa.getFace();
+        auto* leftInfo = dynamic_cast<ElementInfos*>(
+            face->getPtrElementLeft()->getUserData());
+        epsilonLeft = leftInfo->epsilon_;
+        epsMax = epsilonLeft;
+
+        if (face->isInternal()) {
+            auto* rightInfo = dynamic_cast<ElementInfos*>(
+                face->getPtrElementRight()->getUserData());
+            epsilonRight = rightInfo->epsilon_;
+            if (epsilonLeft < epsilonRight) {
+                epsMax = epsilonRight;
+            }
+        } else {
+            // Just in case
+            epsilonRight = std::numeric_limits<double>::signaling_NaN();
+        }
+    }
+
+    double epsilonLeft;
+    double epsilonRight;
+    double epsMax;
+};
+
 // Utility function
 struct FaceDoFInfo {
     std::size_t leftUDoFs;
@@ -126,16 +155,10 @@ void DivDGMaxDiscretization<DIM>::computeElementIntegrands(
 
     LinearAlgebra::MiddleSizeVector vector1(2), vector2(2), sourceVector(2);
 
-    std::size_t totalDoFs = 0, totalUDoFs = 0, totalPDoFs = 0;
-
     auto end = mesh.elementColEnd();
     for (typename Base::MeshManipulator<DIM>::ElementIterator it =
              mesh.elementColBegin();
          it != end; ++it) {
-        totalUDoFs = (*it)->getNumberOfBasisFunctions(0);
-        totalPDoFs = (*it)->getNumberOfBasisFunctions(1);
-        totalDoFs = totalUDoFs + totalPDoFs;
-
         Base::Element* element = *it;
         indexing.reinit(element);
         computeElementMatrices(element, indexing);
@@ -159,7 +182,7 @@ void DivDGMaxDiscretization<DIM>::computeElementIntegrands(
         }
 
         if (sourceTerm) {
-            sourceVector.resize(totalDoFs);
+            sourceVector.resize(indexing.getNumberOfDoFs());
             sourceVector = elementIntegrator_.integrate(
                 (*it), [&](Base::PhysicalElement<DIM>& element) {
                     LinearAlgebra::MiddleSizeVector result;
@@ -176,53 +199,31 @@ void DivDGMaxDiscretization<DIM>::computeFaceIntegrals(
     Base::MeshManipulator<DIM>& mesh,
     DivDGMaxDiscretization<DIM>::FaceInputFunction boundaryCondition,
     Stab stab) {
-    LinearAlgebra::MiddleSizeMatrix faceMatrix(2, 2);
-    LinearAlgebra::MiddleSizeVector faceVector(2);
+    LinearAlgebra::MiddleSizeMatrix faceMatrix;
+    LinearAlgebra::MiddleSizeVector faceVector;
+
+    Utilities::FaceLocalIndexing indexing;
+    indexing.reinit({0, 1});
 
     auto end = mesh.faceColEnd();
-    for (typename Base::MeshManipulator<DIM>::FaceIterator it =
-             mesh.faceColBegin();
-         it != end; ++it) {
+    for (auto it = mesh.faceColBegin(); it != end; ++it) {
 
-        std::size_t totalDoFs = 0;
+        const Base::Face* face = *it;
+        indexing.reinit(face);
 
-        totalDoFs = (*it)->getPtrElementLeft()->getNumberOfBasisFunctions(0) +
-                    (*it)->getPtrElementLeft()->getNumberOfBasisFunctions(1);
-        if ((*it)->isInternal()) {
-            totalDoFs +=
-                (*it)->getPtrElementRight()->getNumberOfBasisFunctions(0) +
-                (*it)->getPtrElementRight()->getNumberOfBasisFunctions(1);
-        }
-
-        faceMatrix.resize(totalDoFs, totalDoFs);
-        faceVector.resize(totalDoFs);
-
-        faceMatrix = faceIntegrator_.integrate(
-            (*it), [&](Base::PhysicalFace<DIM>& face) {
+        std::size_t totalDoFs = indexing.getNumberOfDoFs();
+        faceMatrix =
+            faceIntegrator_.integrate(face, [&](Base::PhysicalFace<DIM>& face) {
                 LinearAlgebra::MiddleSizeMatrix result, temp;
-                faceStiffnessMatrix1(face, result);
+                faceStiffnessMatrix1(face, indexing, stab, result);
 
-                if (stab.fluxType1 == FluxType::IP) {
-                    faceStiffnessMatrix2(face, temp, stab.stab1);
-                    result += temp;
-                    temp *= 0;  // Reset the variable;
-                }
-                if (stab.fluxType2 == FluxType::IP) {
-                    faceStiffnessMatrix3(face, temp, stab.stab2);
-                    result += temp;
-                    temp *= 0;  // Reset the variable;
-                }
-                if (stab.fluxType3 == FluxType::IP) {
-                    faceStiffnessScalarMatrix4(face, temp, stab.stab3);
-                    // Note the matrix contribution is -C.
-                    result -= temp;
-                    temp *= 0;  // Reset the variable;
-                }
+                //                if (stab.fluxType2 == FluxType::IP) {
+                //                    faceStiffnessMatrix3(face, temp,
+                //                    stab.stab2); result += temp;
+                //                }
 
-                faceScalarVectorCoupling(face, temp);
-                result += temp;
+                addScalarFaceMatrixTerms(face, indexing, stab, result);
 
-                // Reset no longer needed.
                 return result;
             });
 
@@ -359,7 +360,8 @@ void DivDGMaxDiscretization<DIM>::computeElementMatrices(
                     pelem.basisFunction(i, phiI, 0);
 
                     for (std::size_t j = 0; j < numPDoFs; ++j) {
-                        double value = (phiI * pelem.basisFunctionDeriv(j, 1)) * -epsilon;
+                        double value =
+                            (phiI * pelem.basisFunctionDeriv(j, 1)) * -epsilon;
                         ret(i, j + offPDoFs) = value;
                         ret(j + offPDoFs, i) = value;
                     }
@@ -413,317 +415,184 @@ void DivDGMaxDiscretization<DIM>::elementSourceVector(
 
 template <std::size_t DIM>
 void DivDGMaxDiscretization<DIM>::faceStiffnessMatrix1(
-    Base::PhysicalFace<DIM>& fa, LinearAlgebra::MiddleSizeMatrix& ret) const {
+    Base::PhysicalFace<DIM>& fa, const Utilities::FaceLocalIndexing& indexing,
+    const Stab& stab, LinearAlgebra::MiddleSizeMatrix& ret) const {
+
     const Base::Face* face = fa.getFace();
-    std::size_t totalUDoFs =
-        face->getPtrElementLeft()->getNumberOfBasisFunctions(0);
-    std::size_t totalPDoFs =
-        face->getPtrElementLeft()->getNumberOfBasisFunctions(1);
+    // For IP fluxes
+    const double stab1 = stab.stab1 / face->getDiameter();
 
-    const std::size_t leftUDoFs = totalUDoFs;
-    const std::size_t leftPDoFs = totalPDoFs;
+    // Mapping from basis function -> face matrix entry
+    std::vector<std::size_t> mapping;
+    indexing.getDoFMapping(0, mapping);
 
-    if (face->isInternal()) {
-        totalUDoFs = face->getPtrElementLeft()->getNumberOfBasisFunctions(0) +
-                     face->getPtrElementRight()->getNumberOfBasisFunctions(0);
-        totalPDoFs = face->getPtrElementLeft()->getNumberOfBasisFunctions(1) +
-                     face->getPtrElementRight()->getNumberOfBasisFunctions(1);
-    }
-    ret.resize(totalUDoFs + totalPDoFs, totalUDoFs + totalPDoFs);
+    const std::size_t totalDoFs = indexing.getNumberOfDoFs();
+    const std::size_t totalUDoFs = mapping.size();
 
-    std::vector<std::size_t> indices(totalUDoFs + totalPDoFs);
-    std::vector<LinearAlgebra::SmallVector<DIM>> phiCurl(totalUDoFs);
-    std::vector<LinearAlgebra::SmallVector<DIM>> phiNormal(totalUDoFs);
+    ret.resize(totalDoFs, totalDoFs);
 
-    // Left element
-    for (std::size_t i = 0; i < leftUDoFs; ++i) {
-        indices[i] = i;
-        phiCurl[i] = fa.basisFunctionCurl(i, 0);
-        fa.basisFunctionUnitNormalCross(i, phiNormal[i], 0);
-    }
-    // Right element
-    for (std::size_t i = leftUDoFs; i < totalUDoFs; ++i) {
-        // Note, only here we need to offset by leftPDoFs, as the indices are
-        // over all unknowns and not just those for one (as in
-        // fa.basisFunction*)
-        indices[i] = i + leftPDoFs;
-        phiCurl[i] = fa.basisFunctionCurl(i, 0);
-        fa.basisFunctionUnitNormalCross(i, phiNormal[i], 0);
-    }
-
+    // Averaging factor
     double factor = face->isInternal() ? -0.5 : -1;
+
+    LinearAlgebra::SmallVector<DIM> phiUNormali, phiUNormalj;
+
     for (std::size_t i = 0; i < totalUDoFs; ++i) {
-        const std::size_t iIndex = indices[i];
+        const std::size_t& iIndex = mapping[i];
+        fa.basisFunctionUnitNormalCross(i, phiUNormali, 0);
+        const auto& phiUCurli = fa.basisFunctionCurl(i, 0);
+
         for (std::size_t j = i; j < totalUDoFs; ++j) {
-            const double entry = factor * (phiCurl[i] * phiNormal[j] +
-                                           phiCurl[j] * phiNormal[i]);
-            const std::size_t jIndex = indices[j];
-            ret(iIndex, jIndex) = entry;
-            ret(jIndex, iIndex) = entry;
-        }
-    }
-}
+            const std::size_t& jIndex = mapping[j];
+            fa.basisFunctionUnitNormalCross(j, phiUNormalj, 0);
+            const auto& phiUCurlj = fa.basisFunctionCurl(j, 0);
 
-template <std::size_t DIM>
-void DivDGMaxDiscretization<DIM>::faceStiffnessMatrix2(
-    Base::PhysicalFace<DIM>& fa, LinearAlgebra::MiddleSizeMatrix& ret,
-    double stab) const {
-    const Base::Face* face = fa.getFace();
-    double diameter = face->getDiameter();
-    std::size_t totalUDoFs =
-        face->getPtrElementLeft()->getNumberOfBasisFunctions(0);
-    std::size_t totalPDoFs =
-        face->getPtrElementLeft()->getNumberOfBasisFunctions(1);
-    std::size_t leftUDoFs = totalUDoFs;
-    std::size_t leftPDoFs = totalPDoFs;
-
-    if (face->isInternal()) {
-        totalUDoFs = face->getPtrElementLeft()->getNumberOfBasisFunctions(0) +
-                     face->getPtrElementRight()->getNumberOfBasisFunctions(0);
-        totalPDoFs = face->getPtrElementLeft()->getNumberOfBasisFunctions(1) +
-                     face->getPtrElementRight()->getNumberOfBasisFunctions(1);
-    }
-
-    ret.resize(totalUDoFs + totalPDoFs, totalUDoFs + totalPDoFs);
-
-    std::vector<std::size_t> indices(totalUDoFs);
-    std::vector<LinearAlgebra::SmallVector<DIM>> phiNormalCross(totalUDoFs);
-
-    // Left element
-    for (std::size_t i = 0; i < leftUDoFs; ++i) {
-        indices[i] = i;
-        fa.basisFunctionUnitNormalCross(i, phiNormalCross[i], 0);
-    }
-    // Right element
-    for (std::size_t i = leftUDoFs; i < totalUDoFs; ++i) {
-        indices[i] = i + leftPDoFs;
-        fa.basisFunctionUnitNormalCross(i, phiNormalCross[i], 0);
-    }
-
-    for (std::size_t i = 0; i < totalUDoFs; ++i) {
-        const std::size_t iIndex = indices[i];
-        for (std::size_t j = 0; j < totalUDoFs; ++j) {
-            const std::size_t jIndex = indices[j];
-            // Possibly scale with mu^{-1} in the future
             double entry =
-                stab / (diameter) * (phiNormalCross[i] * phiNormalCross[j]);
+                factor * (phiUCurli * phiUNormalj + phiUNormali * phiUCurlj);
+
+            if (stab.fluxType1 == FluxType::IP) {
+                entry += stab1 * phiUNormali * phiUNormalj;
+            }
+
             ret(iIndex, jIndex) = entry;
             ret(jIndex, iIndex) = entry;
         }
     }
-}
 
-template <std::size_t DIM>
-void DivDGMaxDiscretization<DIM>::faceStiffnessMatrix3(
-    Base::PhysicalFace<DIM>& fa, LinearAlgebra::MiddleSizeMatrix& ret,
-    double stab2) const {
-    // TODO: Cleanup.
-    const Base::Face* face = fa.getFace();
-    double diameter = face->getDiameter();
-    std::size_t totalUDoFs =
-        face->getPtrElementLeft()->getNumberOfBasisFunctions(0);
-    std::size_t totalPDoFs =
-        face->getPtrElementLeft()->getNumberOfBasisFunctions(1);
-    std::size_t leftUDoFs =
-        totalUDoFs;  // to determine left/right part of totalUDoFs
-    std::size_t leftPDoFs =
-        totalPDoFs;  // to determine left/right part of totalUDoFs
-    if (face->isInternal()) {
+    if (face->isInternal() && stab.fluxType2 == FluxType::IP &&
+        stab.stab2 != 0.0) {
+        // Note checking against 0.0 exactly, as this value is set by the user
+        // and often disabled by setting it to 0.
 
-        totalUDoFs += face->getPtrElementRight()->getNumberOfBasisFunctions(0);
-        totalPDoFs += face->getPtrElementRight()->getNumberOfBasisFunctions(1);
-        ElementInfos* rightInfo = static_cast<ElementInfos*>(
-            face->getPtrElementRight()->getUserData());
-        //}
-        ret.resize(totalUDoFs + totalPDoFs, totalUDoFs + totalPDoFs);
-        ElementInfos* leftInfo = static_cast<ElementInfos*>(
-            face->getPtrElementLeft()->getUserData());
+        // Vector of epsilons
+        FaceMaterialInfo minfo(fa);
+        // Combination of both epsilon and the sign of the normal.
+        std::vector<double> signedEpsilon;
+        {
+            signedEpsilon.resize(totalUDoFs);
+            auto leftEnd = signedEpsilon.begin() +
+                           indexing.getNumberOfDoFs(0, Base::Side::LEFT);
+            std::fill(signedEpsilon.begin(), leftEnd, minfo.epsilonLeft);
+            std::fill(leftEnd, signedEpsilon.end(), -minfo.epsilonRight);
+        }
 
-        const double epsmax = std::max(leftInfo->epsilon_, rightInfo->epsilon_);
-
-        LinearAlgebra::SmallVector<DIM> normal = fa.getUnitNormalVector();
-
-        std::vector<std::size_t> indices(totalUDoFs);
-        std::vector<double> phiNormalEpsilon(totalUDoFs);
+        const double stab2 = stab.stab2 * face->getDiameter() / minfo.epsMax;
+        const LinearAlgebra::SmallVector<DIM>& normal =
+            fa.getUnitNormalVector();
         LinearAlgebra::SmallVector<DIM> phi;
 
-        // Left element
         for (std::size_t i = 0; i < totalUDoFs; ++i) {
-            indices[i] = i;
+            const std::size_t& iIndex = mapping[i];
             fa.basisFunction(i, phi, 0);
-            phiNormalEpsilon[i] = leftInfo->epsilon_ * (phi * normal);
-        }
-        // Right element
-        for (std::size_t i = leftUDoFs; i < totalUDoFs; ++i) {
-            indices[i] = i + leftPDoFs;
-            fa.basisFunction(i, phi, 0);
-            // - from the conversion between the left and right normal
-            phiNormalEpsilon[i] = -rightInfo->epsilon_ * (phi * normal);
-        }
+            double phiUi = phi * normal * signedEpsilon[i];
 
-        for (std::size_t i = 0; i < totalUDoFs; ++i) {
-            const std::size_t iIndex = indices[i];
             for (std::size_t j = i; j < totalUDoFs; ++j) {
-                const std::size_t jIndex = indices[j];
-                // TODO: Scaling
-                double entry = diameter * stab2 / epsmax * phiNormalEpsilon[i] *
-                               phiNormalEpsilon[j];
-                ret(iIndex, jIndex) = entry;
-                ret(jIndex, iIndex) = entry;
+                const std::size_t& jIndex = mapping[j];
+
+                fa.basisFunction(j, phi, 0);
+
+                double value =
+                    stab2 * phiUi * (phi * normal) * signedEpsilon[j];
+                ret(iIndex, jIndex) += value;
+                if (i != j) {
+                    ret(jIndex, iIndex) += value;
+                }
             }
         }
-    } else {
-        ret.resize(totalUDoFs + totalPDoFs, totalUDoFs + totalPDoFs);
     }
 }
 
 template <std::size_t DIM>
-void DivDGMaxDiscretization<DIM>::faceScalarVectorCoupling(
-    Base::PhysicalFace<DIM>& fa, LinearAlgebra::MiddleSizeMatrix& ret) const {
-    const Base::Face* face = fa.getFace();
-    std::size_t totalUDoFs =
-        face->getPtrElementLeft()->getNumberOfBasisFunctions(0);
-    std::size_t totalPDoFs =
-        face->getPtrElementLeft()->getNumberOfBasisFunctions(1);
+void DivDGMaxDiscretization<DIM>::addScalarFaceMatrixTerms(
+    Base::PhysicalFace<DIM>& fa, const Utilities::FaceLocalIndexing& indexing,
+    const Stab& stab, LinearAlgebra::MiddleSizeMatrix& ret) const {
 
-    const double epsilonLeft =
-        static_cast<ElementInfos*>(face->getPtrElementLeft()->getUserData())
-            ->epsilon_;
-    const double epsilonRight =
-        face->isInternal()
-            ? (static_cast<ElementInfos*>(
-                   face->getPtrElementRight()->getUserData())
-                   ->epsilon_)
-            : 1.0;  // If no right face is present this will not be used.
-    // From the averaging terms.
+    // Mapping from basis function -> face matrix entry
+    std::vector<std::size_t> mappingU, mappingP;
+    indexing.getDoFMapping(0, mappingU);
+    indexing.getDoFMapping(1, mappingP);
+
+    const std::size_t totalDoFs = indexing.getNumberOfDoFs();
+    const std::size_t totalUDoFs = mappingU.size();
+    const std::size_t totalPDoFs = mappingP.size();
+
+    ret.resize(totalDoFs, totalDoFs);
+
+    // Averaging averageFactor
+    const Base::Face* face = fa.getFace();
     double averageFactor = face->isInternal() ? 0.5 : 1;
 
-    std::size_t leftUDofs = totalUDoFs;
-    std::size_t leftPDofs = totalPDoFs;
-
-    if (face->isInternal()) {
-        totalUDoFs += face->getPtrElementRight()->getNumberOfBasisFunctions(0);
-        totalPDoFs += face->getPtrElementRight()->getNumberOfBasisFunctions(1);
-    }
-    ret.resize(totalUDoFs + totalPDoFs, totalUDoFs + totalPDoFs);
-
-    LinearAlgebra::SmallVector<DIM> normal = fa.getUnitNormalVector();
-
-    std::vector<std::size_t> indicesU(totalUDoFs);
-    std::vector<std::size_t> indicesP(totalPDoFs);
-    // Note: while the discretization_ say {{ phiU }} * [[phiP]], which leads to
-    // terms (phiP_[lr] n_[lr]) * phiU (subscripts for the left/right element).
-    // We could thus multiply phiP_[lr] by the correct normal and compute the
-    // innerproduct later. For better performance we use that n_l = -n_r, thus
-    // the terms can also be written as (s_[lr] phiP_[lr]) (n_l * phiU), where
-    // s_[lr] is the sign (1 for l, -1 for r). Note that now both terms are
-    // numbers instead of vectors.
-    std::vector<double> phiUNormal(totalUDoFs);
-    std::vector<double> phiP(totalPDoFs);
-    LinearAlgebra::SmallVector<DIM> phiU;
-
-    // Left element U
-    for (std::size_t i = 0; i < leftUDofs; ++i) {
-        indicesU[i] = i;
-        fa.basisFunction(i, phiU, 0);
-        phiUNormal[i] = phiU * normal * epsilonLeft;
-    }
-    // Right element U
-    // Note that for a boundary element leftUDofs == totalUDoFs and this loop is
-    // skipped.
-    for (std::size_t i = leftUDofs; i < totalUDoFs; ++i) {
-        indicesU[i] = i + leftPDofs;
-        fa.basisFunction(i, phiU, 0);
-        phiUNormal[i] = phiU * normal * epsilonRight;
+    // Vector of epsilon, indexed by the U-variable
+    FaceMaterialInfo minfo(fa);
+    std::vector<double> epsilons;
+    {
+        epsilons.resize(totalUDoFs);
+        auto leftEnd =
+            epsilons.begin() + indexing.getNumberOfDoFs(0, Base::Side::LEFT);
+        std::fill(epsilons.begin(), leftEnd, minfo.epsilonLeft);
+        std::fill(leftEnd, epsilons.end(), minfo.epsilonRight);
     }
 
-    // Left element P
-    for (std::size_t i = 0; i < leftPDofs; ++i) {
-        indicesP[i] = leftUDofs + i;
-        phiP[i] = fa.basisFunction(i, 1);
-    }
-    // Right element P, also skipped for boundary elements.
-    for (std::size_t i = leftPDofs; i < totalPDoFs; ++i) {
-        indicesP[i] = totalUDoFs + i;
-        // - because the right normal is -1 times the left normal.
-        phiP[i] = -fa.basisFunction(i, 1);
+    // Factor for the normal, indexed by P-variable;
+    std::vector<int> normalSign;
+    {
+        normalSign.resize(totalPDoFs);
+        auto leftEnd =
+            normalSign.begin() + indexing.getNumberOfDoFs(1, Base::Side::LEFT);
+        std::fill(normalSign.begin(), leftEnd, 1);
+        std::fill(leftEnd, normalSign.end(), -1);
     }
 
+    const auto& normal = fa.getUnitNormalVector();
+    LinearAlgebra::SmallVector<DIM> phiUi;
+
+    /// Scalar vector coupling
+    /// [[p]] {{eps v}} and it's symmetric term [[q]] {{eps u}}
     for (std::size_t i = 0; i < totalUDoFs; ++i) {
-        const std::size_t iIndex = indicesU[i];
-        const double& phiUi = phiUNormal[i];
+        const std::size_t iIndex = mappingU[i];
+        fa.basisFunction(i, phiUi, 0);
+        // Minor standard optimization, the discretization requires
+        // {{epsilon phiUi}} . [[phiQj]]. This translates to:
+        // averageFactor * epsilon(i) phiUi . n(j) phiQj, where epsilon(i) and
+        // n(j) are the value of epsilon and the normal on the same side as the
+        // basis function i and j respectively. As n(right) = -n(left) this is
+        // transformed into
+        // [epsilon(i) phiUi . n(left)] * [phiQj(j) s(j)]
+        // where s(j) = 1.0 for the left values of j, and -1 for the right ones.
+        double epsUNi = (phiUi * normal) * epsilons[i];
+
         for (std::size_t j = 0; j < totalPDoFs; ++j) {
-            const double entry = averageFactor * (phiUi * phiP[j]);
-            const std::size_t jIndex = indicesP[j];
-            ret(iIndex, jIndex) = entry;
-            ret(jIndex, iIndex) = entry;
+            double phiPj = fa.basisFunction(j, 1) * normalSign[j];
+
+            const double entry = averageFactor * epsUNi * phiPj;
+            const std::size_t jIndex = mappingP[j];
+            ret(iIndex, jIndex) += entry;
+            ret(jIndex, iIndex) += entry;
+        }
+    }
+    if (stab.fluxType3 == FluxType::IP) {
+        /// Stabilization of the potential term
+        /// stab3/diameter * epsMax [[p]] [[q]]
+        const double stab3 = stab.stab3 / face->getDiameter() * minfo.epsMax;
+
+        for (std::size_t i = 0; i < totalPDoFs; ++i) {
+            const std::size_t iIndex = mappingP[i];
+            double phiPi = fa.basisFunction(i, 1) * normalSign[i];
+
+            for (std::size_t j = i; j < totalPDoFs; ++j) {
+                const std::size_t jIndex = mappingP[j];
+
+                const double value =
+                    stab3 * phiPi * fa.basisFunction(j, 1) * normalSign[j];
+                // Negative contribution
+                ret(iIndex, jIndex) -= value;
+                if (i != j) {
+                    ret(jIndex, iIndex) -= value;
+                }
+            }
         }
     }
 }
 
-template <std::size_t DIM>
-void DivDGMaxDiscretization<DIM>::faceStiffnessScalarMatrix4(
-    Base::PhysicalFace<DIM>& fa, LinearAlgebra::MiddleSizeMatrix& ret,
-    double stab3) const {
-    // TODO: Cleanup.
-    const Base::Face* face = fa.getFace();
-    double diameter = face->getDiameter();
-    std::size_t totalUDoFs =
-        face->getPtrElementLeft()->getNumberOfBasisFunctions(0);
-    std::size_t totalPDoFs =
-        face->getPtrElementLeft()->getNumberOfBasisFunctions(1);
-
-    const std::size_t leftUDoFs = totalUDoFs;
-    const std::size_t leftPDoFs = totalPDoFs;
-
-    const double epsilonLeft =
-        static_cast<ElementInfos*>(face->getPtrElementLeft()->getUserData())
-            ->epsilon_;
-
-    double epsmax;
-    if (face->isInternal()) {
-        totalUDoFs += face->getPtrElementRight()->getNumberOfBasisFunctions(0);
-        totalPDoFs += face->getPtrElementRight()->getNumberOfBasisFunctions(1);
-        const double epsilonRight =
-            static_cast<ElementInfos*>(
-                face->getPtrElementRight()->getUserData())
-                ->epsilon_;
-        epsmax = std::max(epsilonLeft, epsilonRight);
-    } else {
-        epsmax = epsilonLeft;
-    }
-    ret.resize(totalUDoFs + totalPDoFs, totalUDoFs + totalPDoFs);
-
-    std::vector<std::size_t> indices(totalPDoFs);
-    std::vector<double> phiP(totalPDoFs);
-    // Note we leave out the actual normal as nL * nL = +1, nR * nL = -1, etc.
-    // instead we multiply the right functions by -1.
-
-    // Left element
-    for (std::size_t i = 0; i < leftPDoFs; ++i) {
-        indices[i] = leftUDoFs + i;
-        phiP[i] = fa.basisFunction(i, 1);
-    }
-    // Right element
-    for (std::size_t i = leftPDoFs; i < totalPDoFs; ++i) {
-        indices[i] = totalUDoFs + i;
-        // - from the right normal being -1 times the left normal.
-        phiP[i] = -fa.basisFunction(i, 1);
-    }
-
-    for (std::size_t i = 0; i < totalPDoFs; ++i) {
-        const std::size_t iIndex = indices[i];
-        const double& phiPi = phiP[i];
-        for (std::size_t j = i; j < totalPDoFs; ++j) {
-            // Note, positive here. The minus for the C matrix is added in
-            // computeFaceIntegrals7.
-            const double entry = stab3 / diameter * epsmax * phiP[j] * phiPi;
-            const std::size_t jIndex = indices[j];
-            ret(iIndex, jIndex) = entry;
-            ret(jIndex, iIndex) = entry;
-        }
-    }
-}
 
 template <std::size_t DIM>
 LinearAlgebra::MiddleSizeMatrix

--- a/applications/DG-Max/Algorithms/DivDGMaxDiscretization.h
+++ b/applications/DG-Max/Algorithms/DivDGMaxDiscretization.h
@@ -217,7 +217,7 @@ class DivDGMaxDiscretization : public DivDGMaxDiscretizationBase {
                                   LinearAlgebra::MiddleSizeMatrix& ret) const;
 
     LinearAlgebra::MiddleSizeMatrix brezziFluxBilinearTerm(
-        typename Base::MeshManipulator<DIM>::FaceIterator rawFace, Stab stab);
+        Base::Face* face, Stab stab);
 
     /// \brief Compute mass matrix for vector components on elements adjacent to
     /// a face
@@ -229,19 +229,19 @@ class DivDGMaxDiscretization : public DivDGMaxDiscretizationBase {
     ///
     /// Note that the resulting matrix only contains the degrees of freedom for
     /// the vector valued basis functions.
-    /// \param rawFace The face to compute the local mass matrix for
+    /// \param face The face to compute the local mass matrix for
     /// \return The mass matrix
     LinearAlgebra::MiddleSizeMatrix computeFaceVectorMassMatrix(
-        typename Base::MeshManipulator<DIM>::FaceIterator rawFace);
+        Base::Face* face);
 
     /// \brief Compute mass matrix for scalar basis functions on elements
     /// adjacent to a face
     ///
     /// Same as computeFaceVectorMassMatrix but for the scalar basis functions.
-    /// \param rawFace The face to compute the matrix forr
+    /// \param face The face to compute the matrix forr
     /// \return The mass matrix
     LinearAlgebra::MiddleSizeMatrix computeFaceScalarMassMatrix(
-        typename Base::MeshManipulator<DIM>::FaceIterator rawFace);
+        Base::Face* face);
 
     /// \brief Compute projection matrix of the jump of the scalar basis
     /// functions
@@ -254,10 +254,10 @@ class DivDGMaxDiscretization : public DivDGMaxDiscretizationBase {
     ///
     /// This term is needed for the implementation of the lifting operator for
     /// the Brezzi fluxes.
-    /// \param rawFace The face to compute it on
+    /// \param face The face to compute it on
     /// \return The (dofs u) by (dofs p) projection matrix.
     LinearAlgebra::MiddleSizeMatrix computeScalarLiftProjector(
-        typename Base::MeshManipulator<DIM>::FaceIterator rawFace);
+        Base::Face* face);
 
     /// \brief Compute the projection matrix of the tangential jump of the
     /// vector
@@ -268,10 +268,10 @@ class DivDGMaxDiscretization : public DivDGMaxDiscretizationBase {
     /// with u_i, u_j the vector basis functions and n the outward pointing
     /// normal
     ///   to the element on which u_j has support.
-    /// \param rawFace The face to compute it on
+    /// \param face The face to compute it on
     /// \return The (dofs u)^2 projection matrix.
     LinearAlgebra::MiddleSizeMatrix computeVectorLiftProjector(
-        typename Base::MeshManipulator<DIM>::FaceIterator rawFace);
+        Base::Face* face);
 
     /// \brief Compute the projection matrix for the normal part of the
     ///         vector basis functions in the lifting operators.
@@ -281,10 +281,10 @@ class DivDGMaxDiscretization : public DivDGMaxDiscretizationBase {
     /// with u_j and p_i the basis functions for the vector part and scalar part
     /// and epsilon is the permittivity.
     ///
-    /// \param rawFace The face to compute it on
+    /// \param face The face to compute it on
     /// \return The (dofs p) by (dofs u) projection matrix.
     LinearAlgebra::MiddleSizeMatrix computeVectorNormalLiftProjector(
-        typename Base::MeshManipulator<DIM>::FaceIterator rawFace);
+        Base::Face* face);
 
     void faceBoundaryVector(Base::PhysicalFace<DIM>& fa,
                             const FaceInputFunction& boundaryValue,
@@ -294,7 +294,7 @@ class DivDGMaxDiscretization : public DivDGMaxDiscretizationBase {
     /// Compute contribution of the brezzi flux to the face vector on the
     /// boundary
     LinearAlgebra::MiddleSizeVector brezziFluxBoundaryVector(
-        typename Base::MeshManipulator<DIM>::FaceIterator rawFace,
+        Base::Face* face,
         const FaceInputFunction& boundaryValue, Stab stab);
 
     double elementErrorIntegrand(Base::PhysicalElement<DIM>& el,

--- a/applications/DG-Max/Algorithms/DivDGMaxDiscretization.h
+++ b/applications/DG-Max/Algorithms/DivDGMaxDiscretization.h
@@ -196,27 +196,25 @@ class DivDGMaxDiscretization : public DivDGMaxDiscretizationBase {
                              const InputFunction& source,
                              LinearAlgebra::MiddleSizeVector& ret) const;
 
-    /// The part -[[v]]_t {{mu^{-1} curl u}} - [[u]]_t {{mu^{-1} curl v}} of the
-    /// stiffness integrand.
+    /// Part 1 of face integrand for the stiffness matrix. Consists of the
+    /// terms:
+    ///
+    ///  1.  -[[v]]_t {{mu^{-1} curl u}} - [[u]]_t {{mu^{-1} curl v}}
+    ///  2. For IP-stab1: stab1/diameter * [[u]]_t [[v]]_t
+    ///  3. For IP-stab2: stab2*diameter/espMax [[eps u]]_n . [[eps v]]_n
     void faceStiffnessMatrix1(Base::PhysicalFace<DIM>& fa,
+                              const Utilities::FaceLocalIndexing& indexing,
+                              const Stab& stab,
                               LinearAlgebra::MiddleSizeMatrix& ret) const;
-    /// The tangential stability term stab * [[u]]_T [[v]]_T part of the
-    /// stiffness integrand
-    void faceStiffnessMatrix2(Base::PhysicalFace<DIM>& fa,
-                              LinearAlgebra::MiddleSizeMatrix& ret,
-                              double stab1) const;
-    /// The normal stability term stab [[eps u]]_N [[eps v]]_N
-    void faceStiffnessMatrix3(Base::PhysicalFace<DIM>& fa,
-                              LinearAlgebra::MiddleSizeMatrix& ret,
-                              double stab2) const;
-    /// The face part of B and B^T, [[p]]_N {{eps v}}
-    void faceScalarVectorCoupling(Base::PhysicalFace<DIM>& fa,
+    /// Part 2 of the face integrand for the stiffness matrix, consisting of the
+    /// terms with the potential. This contributes two parts
+    ///
+    ///  1. The coupling scalar-vector: [[p]] {{eps v}}
+    ///  2. For IP-stab3: stab3/diameter * epsMax [[p]] [[q]]
+    void addScalarFaceMatrixTerms(Base::PhysicalFace<DIM>& fa,
+                                  const Utilities::FaceLocalIndexing& indexing,
+                                  const Stab& stab,
                                   LinearAlgebra::MiddleSizeMatrix& ret) const;
-    /// Matrix C, stab [[p]]_N [[q]]_n, note that C itself has a minus
-    /// contribution.
-    void faceStiffnessScalarMatrix4(Base::PhysicalFace<DIM>& fa,
-                                    LinearAlgebra::MiddleSizeMatrix& ret,
-                                    double stab3) const;
 
     LinearAlgebra::MiddleSizeMatrix brezziFluxBilinearTerm(
         typename Base::MeshManipulator<DIM>::FaceIterator rawFace, Stab stab);

--- a/applications/DG-Max/Algorithms/DivDGMaxDiscretization.h
+++ b/applications/DG-Max/Algorithms/DivDGMaxDiscretization.h
@@ -203,19 +203,19 @@ class DivDGMaxDiscretization : public DivDGMaxDiscretizationBase {
     ///  1.  -[[v]]_t {{mu^{-1} curl u}} - [[u]]_t {{mu^{-1} curl v}}
     ///  2. For IP-stab1: stab1/diameter * [[u]]_t [[v]]_t
     ///  3. For IP-stab2: stab2*diameter/espMax [[eps u]]_n . [[eps v]]_n
-    void faceStiffnessMatrix1(Base::PhysicalFace<DIM>& fa,
-                              const Utilities::FaceLocalIndexing& indexing,
-                              const Stab& stab,
-                              LinearAlgebra::MiddleSizeMatrix& ret) const;
+    void faceStiffnessMatrixFieldIntegrand(
+        Base::PhysicalFace<DIM>& fa,
+        const Utilities::FaceLocalIndexing& indexing, const Stab& stab,
+        LinearAlgebra::MiddleSizeMatrix& ret) const;
     /// Part 2 of the face integrand for the stiffness matrix, consisting of the
     /// terms with the potential. This contributes two parts
     ///
     ///  1. The coupling scalar-vector: [[p]] {{eps v}}
     ///  2. For IP-stab3: stab3/diameter * epsMax [[p]] [[q]]
-    void addScalarFaceMatrixTerms(Base::PhysicalFace<DIM>& fa,
-                                  const Utilities::FaceLocalIndexing& indexing,
-                                  const Stab& stab,
-                                  LinearAlgebra::MiddleSizeMatrix& ret) const;
+    void addFaceMatrixPotentialIntegrand(
+        Base::PhysicalFace<DIM>& fa,
+        const Utilities::FaceLocalIndexing& indexing, const Stab& stab,
+        LinearAlgebra::MiddleSizeMatrix& ret) const;
 
     LinearAlgebra::MiddleSizeMatrix brezziFluxBilinearTerm(Base::Face* face,
                                                            Stab stab);

--- a/applications/DG-Max/Algorithms/DivDGMaxDiscretization.h
+++ b/applications/DG-Max/Algorithms/DivDGMaxDiscretization.h
@@ -42,11 +42,12 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <functional>
 #include <memory>
 
+#include "Base/HCurlConformingTransformation.h"
+#include "Base/H1ConformingTransformation.h"
 #include "Base/MeshManipulator.h"
 #include "Integration/ElementIntegral.h"
 #include "Integration/FaceIntegral.h"
-#include "Base/HCurlConformingTransformation.h"
-#include "Base/H1ConformingTransformation.h"
+#include "Utilities/ElementLocalIndexing.h"
 
 // Forward definitions
 namespace hpgem {
@@ -153,8 +154,7 @@ class DivDGMaxDiscretization : public DivDGMaxDiscretizationBase {
         const InputFunction& initialConditionDerivative);
 
     void computeFaceIntegrals(Base::MeshManipulator<DIM>& mesh,
-                              FaceInputFunction boundaryCondition,
-                              Stab stab);
+                              FaceInputFunction boundaryCondition, Stab stab);
 
     // TODO: LJ include the same norms as in DGMaxDiscretization
     double computeL2Error(Base::MeshManipulator<DIM>& mesh,
@@ -177,12 +177,10 @@ class DivDGMaxDiscretization : public DivDGMaxDiscretizationBase {
         const LinearAlgebra::MiddleSizeVector& coefficients) const;
 
    private:
-    /// Element part of matrix M, with zero matrices around it (u, v)
-    void elementMassMatrix(Base::PhysicalElement<DIM>& el,
-                           LinearAlgebra::MiddleSizeMatrix& ret) const;
-    /// Element part of matrix A, with zeros around it,  (curl u, curl v)
-    void elementStiffnessMatrix(Base::PhysicalElement<DIM>& el,
-                                LinearAlgebra::MiddleSizeMatrix& ret) const;
+    /// Compute Mass and Stiffness matrix for the element
+    void computeElementMatrices(Base::Element* element,
+                                Utilities::ElementLocalIndexing& indexing);
+
     /// Element part of matrix B and B^T, with zeros around it (- grad p, eps v)
     void elementScalarVectorCoupling(
         Base::PhysicalElement<DIM>& el,
@@ -216,8 +214,7 @@ class DivDGMaxDiscretization : public DivDGMaxDiscretizationBase {
                                     double stab3) const;
 
     LinearAlgebra::MiddleSizeMatrix brezziFluxBilinearTerm(
-        typename Base::MeshManipulator<DIM>::FaceIterator rawFace,
-        Stab stab);
+        typename Base::MeshManipulator<DIM>::FaceIterator rawFace, Stab stab);
 
     /// \brief Compute mass matrix for vector components on elements adjacent to
     /// a face

--- a/applications/DG-Max/Algorithms/DivDGMaxDiscretization.h
+++ b/applications/DG-Max/Algorithms/DivDGMaxDiscretization.h
@@ -47,7 +47,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "Base/MeshManipulator.h"
 #include "Integration/ElementIntegral.h"
 #include "Integration/FaceIntegral.h"
-#include "Utilities/ElementLocalIndexing.h"
 
 // Forward definitions
 namespace hpgem {
@@ -65,6 +64,12 @@ class MiddleSizeVector;
 template <std::size_t DIM>
 class SmallVector;
 }  // namespace LinearAlgebra
+
+namespace Utilities {
+class ElementLocalIndexing;
+class FaceLocalIndexing;
+}  // namespace Utilities
+
 }  // namespace hpgem
 
 /// Base class with all dimensionless constants

--- a/applications/DG-Max/Algorithms/DivDGMaxDiscretization.h
+++ b/applications/DG-Max/Algorithms/DivDGMaxDiscretization.h
@@ -155,11 +155,12 @@ class DivDGMaxDiscretization : public DivDGMaxDiscretizationBase {
 
     void computeElementIntegrands(
         Base::MeshManipulator<DIM>& mesh, bool invertMassMatrix,
-        const InputFunction& sourceTerm, const InputFunction& initialCondition,
-        const InputFunction& initialConditionDerivative);
+        const std::map<std::size_t, InputFunction>& elementVectors);
 
-    void computeFaceIntegrals(Base::MeshManipulator<DIM>& mesh,
-                              FaceInputFunction boundaryCondition, Stab stab);
+    void computeFaceIntegrals(
+        Base::MeshManipulator<DIM>& mesh,
+        const std::map<std::size_t, FaceInputFunction>& boundaryVectors,
+        Stab stab);
 
     // TODO: LJ include the same norms as in DGMaxDiscretization
     double computeL2Error(Base::MeshManipulator<DIM>& mesh,
@@ -216,8 +217,8 @@ class DivDGMaxDiscretization : public DivDGMaxDiscretizationBase {
                                   const Stab& stab,
                                   LinearAlgebra::MiddleSizeMatrix& ret) const;
 
-    LinearAlgebra::MiddleSizeMatrix brezziFluxBilinearTerm(
-        Base::Face* face, Stab stab);
+    LinearAlgebra::MiddleSizeMatrix brezziFluxBilinearTerm(Base::Face* face,
+                                                           Stab stab);
 
     /// \brief Compute mass matrix for vector components on elements adjacent to
     /// a face
@@ -294,8 +295,7 @@ class DivDGMaxDiscretization : public DivDGMaxDiscretizationBase {
     /// Compute contribution of the brezzi flux to the face vector on the
     /// boundary
     LinearAlgebra::MiddleSizeVector brezziFluxBoundaryVector(
-        Base::Face* face,
-        const FaceInputFunction& boundaryValue, Stab stab);
+        Base::Face* face, const FaceInputFunction& boundaryValue, Stab stab);
 
     double elementErrorIntegrand(Base::PhysicalElement<DIM>& el,
                                  std::size_t timeVector,

--- a/applications/DG-Max/Algorithms/DivDGMaxDiscretization.h
+++ b/applications/DG-Max/Algorithms/DivDGMaxDiscretization.h
@@ -154,7 +154,7 @@ class DivDGMaxDiscretization : public DivDGMaxDiscretizationBase {
                                   std::size_t order);
 
     void computeElementIntegrands(
-        Base::MeshManipulator<DIM>& mesh, bool invertMassMatrix,
+        Base::MeshManipulator<DIM>& mesh,
         const std::map<std::size_t, InputFunction>& elementVectors);
 
     void computeFaceIntegrals(

--- a/applications/DG-Max/Algorithms/DivDGMaxDiscretization.h
+++ b/applications/DG-Max/Algorithms/DivDGMaxDiscretization.h
@@ -43,6 +43,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <memory>
 
 #include "Base/MeshManipulator.h"
+#include "Integration/ElementIntegral.h"
+#include "Integration/FaceIntegral.h"
+#include "Base/HCurlConformingTransformation.h"
+#include "Base/H1ConformingTransformation.h"
 
 // Forward definitions
 namespace hpgem {
@@ -138,22 +142,24 @@ class DivDGMaxDiscretization : public DivDGMaxDiscretizationBase {
     using FaceInputFunction = std::function<LinearAlgebra::SmallVector<DIM>(
         Base::PhysicalFace<DIM>&)>;
 
+    DivDGMaxDiscretization();
+
     void initializeBasisFunctions(Base::MeshManipulator<DIM>& mesh,
                                   std::size_t order);
 
     void computeElementIntegrands(
         Base::MeshManipulator<DIM>& mesh, bool invertMassMatrix,
         const InputFunction& sourceTerm, const InputFunction& initialCondition,
-        const InputFunction& initialConditionDerivative) const;
+        const InputFunction& initialConditionDerivative);
 
     void computeFaceIntegrals(Base::MeshManipulator<DIM>& mesh,
                               FaceInputFunction boundaryCondition,
-                              Stab stab) const;
+                              Stab stab);
 
     // TODO: LJ include the same norms as in DGMaxDiscretization
     double computeL2Error(Base::MeshManipulator<DIM>& mesh,
                           std::size_t timeVector,
-                          const InputFunction& electricField) const;
+                          const InputFunction& electricField);
 
     Fields computeFields(
         const Base::Element* element,
@@ -211,7 +217,7 @@ class DivDGMaxDiscretization : public DivDGMaxDiscretizationBase {
 
     LinearAlgebra::MiddleSizeMatrix brezziFluxBilinearTerm(
         typename Base::MeshManipulator<DIM>::FaceIterator rawFace,
-        Stab stab) const;
+        Stab stab);
 
     /// \brief Compute mass matrix for vector components on elements adjacent to
     /// a face
@@ -226,7 +232,7 @@ class DivDGMaxDiscretization : public DivDGMaxDiscretizationBase {
     /// \param rawFace The face to compute the local mass matrix for
     /// \return The mass matrix
     LinearAlgebra::MiddleSizeMatrix computeFaceVectorMassMatrix(
-        typename Base::MeshManipulator<DIM>::FaceIterator rawFace) const;
+        typename Base::MeshManipulator<DIM>::FaceIterator rawFace);
 
     /// \brief Compute mass matrix for scalar basis functions on elements
     /// adjacent to a face
@@ -235,7 +241,7 @@ class DivDGMaxDiscretization : public DivDGMaxDiscretizationBase {
     /// \param rawFace The face to compute the matrix forr
     /// \return The mass matrix
     LinearAlgebra::MiddleSizeMatrix computeFaceScalarMassMatrix(
-        typename Base::MeshManipulator<DIM>::FaceIterator rawFace) const;
+        typename Base::MeshManipulator<DIM>::FaceIterator rawFace);
 
     /// \brief Compute projection matrix of the jump of the scalar basis
     /// functions
@@ -251,7 +257,7 @@ class DivDGMaxDiscretization : public DivDGMaxDiscretizationBase {
     /// \param rawFace The face to compute it on
     /// \return The (dofs u) by (dofs p) projection matrix.
     LinearAlgebra::MiddleSizeMatrix computeScalarLiftProjector(
-        typename Base::MeshManipulator<DIM>::FaceIterator rawFace) const;
+        typename Base::MeshManipulator<DIM>::FaceIterator rawFace);
 
     /// \brief Compute the projection matrix of the tangential jump of the
     /// vector
@@ -265,7 +271,7 @@ class DivDGMaxDiscretization : public DivDGMaxDiscretizationBase {
     /// \param rawFace The face to compute it on
     /// \return The (dofs u)^2 projection matrix.
     LinearAlgebra::MiddleSizeMatrix computeVectorLiftProjector(
-        typename Base::MeshManipulator<DIM>::FaceIterator rawFace) const;
+        typename Base::MeshManipulator<DIM>::FaceIterator rawFace);
 
     /// \brief Compute the projection matrix for the normal part of the
     ///         vector basis functions in the lifting operators.
@@ -278,7 +284,7 @@ class DivDGMaxDiscretization : public DivDGMaxDiscretizationBase {
     /// \param rawFace The face to compute it on
     /// \return The (dofs p) by (dofs u) projection matrix.
     LinearAlgebra::MiddleSizeMatrix computeVectorNormalLiftProjector(
-        typename Base::MeshManipulator<DIM>::FaceIterator rawFace) const;
+        typename Base::MeshManipulator<DIM>::FaceIterator rawFace);
 
     void faceBoundaryVector(Base::PhysicalFace<DIM>& fa,
                             const FaceInputFunction& boundaryValue,
@@ -289,11 +295,17 @@ class DivDGMaxDiscretization : public DivDGMaxDiscretizationBase {
     /// boundary
     LinearAlgebra::MiddleSizeVector brezziFluxBoundaryVector(
         typename Base::MeshManipulator<DIM>::FaceIterator rawFace,
-        const FaceInputFunction& boundaryValue, Stab stab) const;
+        const FaceInputFunction& boundaryValue, Stab stab);
 
     double elementErrorIntegrand(Base::PhysicalElement<DIM>& el,
                                  std::size_t timeVector,
                                  const InputFunction& exactValues) const;
+
+    /// Shared parts for computing integrals
+    Integration::ElementIntegral<DIM> elementIntegrator_;
+    Integration::FaceIntegral<DIM> faceIntegrator_;
+    std::shared_ptr<Base::HCurlConformingTransformation<DIM>> fieldTransform_;
+    std::shared_ptr<Base::H1ConformingTransformation<DIM>> potentialTransform_;
 };
 
 // TODO: Deduction fails for a templated variant, hence using explicit versions

--- a/applications/DG-Max/Algorithms/DivDGMaxDiscretization.h
+++ b/applications/DG-Max/Algorithms/DivDGMaxDiscretization.h
@@ -61,25 +61,10 @@ template <std::size_t DIM>
 class SmallVector;
 }  // namespace LinearAlgebra
 }  // namespace hpgem
-using namespace hpgem;
-/// \brief Discontinuous Galerkin discretization for Maxwell, where the
-/// divergence constraint (div E = 0) is part of the discretization.
-///
-/// This implementation is based on chapter 5 of Devashish2017PhD, and similar
-/// to for example Lu2016JSciComput. It decomposes E = u + grad p, forming a
-/// mixed system (for eigenvalue problems) of the form
-/// [ A   B ] [u] = λ [ M 0 ] [u]
-/// [ BT -C ] [p]     [ 0 0 ] [p]
-///
-/// Where A corresponds to the curl-curl operator, B the coupling between
-/// u and p, and C is a stabilization term. The matrix M is the mass
-/// matrix, corresponding to the omega^2 E term in the timeharmonic
-/// formulation.
-template <std::size_t DIM>
-class DivDGMaxDiscretization {
-   public:
-    // TODO: static const std::size_t matrix/vector ids
 
+/// Base class with all dimensionless constants
+class DivDGMaxDiscretizationBase {
+   public:
     static const std::size_t ELEMENT_MASS_MATRIX_ID = 0;
     static const std::size_t ELEMENT_STIFFNESS_MATRIX_ID = 1;
     // Note: Missing are the initial conditions, taking up positions 0, 1
@@ -115,6 +100,26 @@ class DivDGMaxDiscretization {
             fluxType3 = type;
         }
     };
+};
+
+using namespace hpgem;
+/// \brief Discontinuous Galerkin discretization for Maxwell, where the
+/// divergence constraint (div E = 0) is part of the discretization.
+///
+/// This implementation is based on chapter 5 of Devashish2017PhD, and similar
+/// to for example Lu2016JSciComput. It decomposes E = u + grad p, forming a
+/// mixed system (for eigenvalue problems) of the form
+/// [ A   B ] [u] = λ [ M 0 ] [u]
+/// [ BT -C ] [p]     [ 0 0 ] [p]
+///
+/// Where A corresponds to the curl-curl operator, B the coupling between
+/// u and p, and C is a stabilization term. The matrix M is the mass
+/// matrix, corresponding to the omega^2 E term in the timeharmonic
+/// formulation.
+template <std::size_t DIM>
+class DivDGMaxDiscretization : public DivDGMaxDiscretizationBase {
+   public:
+    // TODO: static const std::size_t matrix/vector ids
 
     /// Value class for the solution.
     struct Fields {
@@ -295,8 +300,6 @@ class DivDGMaxDiscretization {
 // here
 
 std::ostream& operator<<(std::ostream& os,
-                         typename DivDGMaxDiscretization<2>::Stab& stab);
-std::ostream& operator<<(std::ostream& os,
-                         typename DivDGMaxDiscretization<3>::Stab& stab);
+                         const DivDGMaxDiscretizationBase::Stab& stab);
 
 #endif  // HPGEM_APP_DIVDGMAXDISCRETIZATION_H

--- a/applications/DG-Max/Algorithms/DivDGMaxEigenvalue.cpp
+++ b/applications/DG-Max/Algorithms/DivDGMaxEigenvalue.cpp
@@ -359,9 +359,9 @@ void DivDGMaxEigenvalue<DIM>::solve(
     PetscErrorCode error;
     DGMaxLogger(INFO, "Starting assembly");
     discretization.initializeBasisFunctions(mesh_, order_);
-    discretization.computeElementIntegrands(mesh_, false, nullptr, nullptr,
-                                            nullptr);
-    discretization.computeFaceIntegrals(mesh_, nullptr, stab_);
+    discretization.computeElementIntegrands(mesh_, false,
+                                            {});
+    discretization.computeFaceIntegrals(mesh_, {}, stab_);
 
     SolverWorkspace workspace(&mesh_);
 

--- a/applications/DG-Max/Algorithms/DivDGMaxEigenvalue.cpp
+++ b/applications/DG-Max/Algorithms/DivDGMaxEigenvalue.cpp
@@ -359,8 +359,7 @@ void DivDGMaxEigenvalue<DIM>::solve(
     PetscErrorCode error;
     DGMaxLogger(INFO, "Starting assembly");
     discretization.initializeBasisFunctions(mesh_, order_);
-    discretization.computeElementIntegrands(mesh_, false,
-                                            {});
+    discretization.computeElementIntegrands(mesh_, false, {});
     discretization.computeFaceIntegrals(mesh_, {}, stab_);
 
     SolverWorkspace workspace(&mesh_);

--- a/applications/DG-Max/Algorithms/DivDGMaxEigenvalue.cpp
+++ b/applications/DG-Max/Algorithms/DivDGMaxEigenvalue.cpp
@@ -59,10 +59,10 @@ class DivDGMaxEigenvalue<DIM>::SolverWorkspace {
         : indexing_(nullptr),
           stiffnessMatrix_(
               indexing_,
-              DivDGMaxDiscretization<DIM>::ELEMENT_STIFFNESS_MATRIX_ID,
-              DivDGMaxDiscretization<DIM>::FACE_STIFFNESS_MATRIX_ID),
+              DivDGMaxDiscretizationBase::ELEMENT_STIFFNESS_MATRIX_ID,
+              DivDGMaxDiscretizationBase::FACE_STIFFNESS_MATRIX_ID),
           massMatrix_(indexing_,
-                      DivDGMaxDiscretization<DIM>::ELEMENT_MASS_MATRIX_ID, -1),
+                      DivDGMaxDiscretizationBase::ELEMENT_MASS_MATRIX_ID, -1),
           tempVector_(indexing_, -1, -1),
           solver_(nullptr) {
         // Separate from initializer list to allow for more flexibility
@@ -173,7 +173,7 @@ class DivDGMaxEigenvalue<DIM>::SolverWorkspace {
         DGMax::FaceMatrixKPhaseShiftBuilder<DIM> builder;
         builder.setMatrixExtractor([&](const Base::Face* face) {
             const Base::FaceMatrix& faceMatrix = face->getFaceMatrix(
-                DivDGMaxDiscretization<DIM>::FACE_STIFFNESS_MATRIX_ID);
+                DivDGMaxDiscretizationBase::FACE_STIFFNESS_MATRIX_ID);
             LinearAlgebra::MiddleSizeMatrix block1, block2;
             block1 = faceMatrix.getElementMatrix(Base::Side::LEFT,
                                                  Base::Side::RIGHT);
@@ -344,7 +344,7 @@ void DivDGMaxEigenvalue<DIM>::Result::writeField(
 template <std::size_t DIM>
 DivDGMaxEigenvalue<DIM>::DivDGMaxEigenvalue(
     Base::MeshManipulator<DIM>& mesh, std::size_t order,
-    typename DivDGMaxDiscretization<DIM>::Stab stab)
+    DivDGMaxDiscretizationBase::Stab stab)
     : mesh_(mesh), order_(order), stab_(stab) {}
 
 template <std::size_t DIM>

--- a/applications/DG-Max/Algorithms/DivDGMaxEigenvalue.cpp
+++ b/applications/DG-Max/Algorithms/DivDGMaxEigenvalue.cpp
@@ -359,7 +359,7 @@ void DivDGMaxEigenvalue<DIM>::solve(
     PetscErrorCode error;
     DGMaxLogger(INFO, "Starting assembly");
     discretization.initializeBasisFunctions(mesh_, order_);
-    discretization.computeElementIntegrands(mesh_, false, {});
+    discretization.computeElementIntegrands(mesh_, {});
     discretization.computeFaceIntegrals(mesh_, {}, stab_);
 
     SolverWorkspace workspace(&mesh_);

--- a/applications/DG-Max/Algorithms/DivDGMaxEigenvalue.h
+++ b/applications/DG-Max/Algorithms/DivDGMaxEigenvalue.h
@@ -54,12 +54,12 @@ template <std::size_t DIM>
 class DivDGMaxEigenvalue : public AbstractEigenvalueSolver<DIM> {
    public:
     DivDGMaxEigenvalue(Base::MeshManipulator<DIM>& mesh, std::size_t order,
-                       typename DivDGMaxDiscretization<DIM>::Stab stab);
+                       DivDGMaxDiscretizationBase::Stab stab);
     void solve(AbstractEigenvalueSolverDriver<DIM>& driver) override;
 
    private:
     Base::MeshManipulator<DIM>& mesh_;
-    typename DivDGMaxDiscretization<DIM>::Stab stab_;
+    DivDGMaxDiscretizationBase::Stab stab_;
     std::size_t order_;
     DivDGMaxDiscretization<DIM> discretization;
 

--- a/applications/DG-Max/Algorithms/DivDGMaxHarmonic.cpp
+++ b/applications/DG-Max/Algorithms/DivDGMaxHarmonic.cpp
@@ -50,7 +50,7 @@ using namespace hpgem;
 template <std::size_t DIM>
 DivDGMaxHarmonic<DIM>::DivDGMaxHarmonic(
     Base::MeshManipulator<DIM>& mesh,
-    typename DivDGMaxDiscretization<DIM>::Stab stab, std::size_t order)
+    DivDGMaxDiscretizationBase::Stab stab, std::size_t order)
     : mesh_(mesh), stab_(stab) {
     discretization_.initializeBasisFunctions(mesh_, order);
 }
@@ -72,13 +72,13 @@ void DivDGMaxHarmonic<DIM>::solve(const HarmonicProblem<DIM>& input) {
 
     Utilities::GlobalIndexing indexing(&mesh_);
     Utilities::GlobalPetscMatrix massMatrix(
-        indexing, DivDGMaxDiscretization<DIM>::ELEMENT_MASS_MATRIX_ID, -1),
+        indexing, DivDGMaxDiscretizationBase::ELEMENT_MASS_MATRIX_ID, -1),
         stiffnessMatrix(
-            indexing, DivDGMaxDiscretization<DIM>::ELEMENT_STIFFNESS_MATRIX_ID,
-            DivDGMaxDiscretization<DIM>::FACE_STIFFNESS_MATRIX_ID);
+            indexing, DivDGMaxDiscretizationBase::ELEMENT_STIFFNESS_MATRIX_ID,
+            DivDGMaxDiscretizationBase::FACE_STIFFNESS_MATRIX_ID);
     Utilities::GlobalPetscVector rhs(
-        indexing, DivDGMaxDiscretization<DIM>::ELEMENT_SOURCE_VECTOR_ID,
-        DivDGMaxDiscretization<DIM>::FACE_BOUNDARY_VECTOR_ID),
+        indexing, DivDGMaxDiscretizationBase::ELEMENT_SOURCE_VECTOR_ID,
+        DivDGMaxDiscretizationBase::FACE_BOUNDARY_VECTOR_ID),
         result(indexing, -1, -1);
 
     rhs.assemble();

--- a/applications/DG-Max/Algorithms/DivDGMaxHarmonic.cpp
+++ b/applications/DG-Max/Algorithms/DivDGMaxHarmonic.cpp
@@ -66,7 +66,7 @@ void DivDGMaxHarmonic<DIM>::solve(const HarmonicProblem<DIM>& input) {
             elementVecs = {{Discretization::ELEMENT_SOURCE_VECTOR_ID,
                             std::bind(&HarmonicProblem<DIM>::sourceTerm,
                                       std::ref(input), std::placeholders::_1)}};
-        discretization_.computeElementIntegrands(mesh_, false, elementVecs);
+        discretization_.computeElementIntegrands(mesh_, elementVecs);
     }
     {
         std::map<std::size_t, typename Discretization::FaceInputFunction>

--- a/applications/DG-Max/Algorithms/DivDGMaxHarmonic.cpp
+++ b/applications/DG-Max/Algorithms/DivDGMaxHarmonic.cpp
@@ -198,14 +198,13 @@ void DivDGMaxHarmonic<DIM>::writeTec(std::string fileName) const {
 
 template <std::size_t DIM>
 double DivDGMaxHarmonic<DIM>::computeL2Error(
-    const typename DivDGMaxDiscretization<DIM>::InputFunction& exactSolution)
-    const {
+    const typename DivDGMaxDiscretization<DIM>::InputFunction& exactSolution){
     return discretization_.computeL2Error(mesh_, 0, exactSolution);
 }
 
 template <std::size_t DIM>
 double DivDGMaxHarmonic<DIM>::computeL2Error(
-    const ExactHarmonicProblem<DIM>& problem) const {
+    const ExactHarmonicProblem<DIM>& problem) {
     return computeL2Error(std::bind(&ExactHarmonicProblem<DIM>::exactSolution,
                                     std::ref(problem), std::placeholders::_1));
 }

--- a/applications/DG-Max/Algorithms/DivDGMaxHarmonic.cpp
+++ b/applications/DG-Max/Algorithms/DivDGMaxHarmonic.cpp
@@ -48,9 +48,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 using namespace hpgem;
 
 template <std::size_t DIM>
-DivDGMaxHarmonic<DIM>::DivDGMaxHarmonic(
-    Base::MeshManipulator<DIM>& mesh,
-    DivDGMaxDiscretizationBase::Stab stab, std::size_t order)
+DivDGMaxHarmonic<DIM>::DivDGMaxHarmonic(Base::MeshManipulator<DIM>& mesh,
+                                        DivDGMaxDiscretizationBase::Stab stab,
+                                        std::size_t order)
     : mesh_(mesh), stab_(stab) {
     discretization_.initializeBasisFunctions(mesh_, order);
 }
@@ -59,23 +59,29 @@ template <std::size_t DIM>
 void DivDGMaxHarmonic<DIM>::solve(const HarmonicProblem<DIM>& input) {
     PetscErrorCode error;
 
-    discretization_.computeElementIntegrands(
-        mesh_, false,
-        std::bind(&HarmonicProblem<DIM>::sourceTerm, std::ref(input),
-                  std::placeholders::_1),
-        nullptr, nullptr);
-    discretization_.computeFaceIntegrals(
-        mesh_,
-        std::bind(&HarmonicProblem<DIM>::boundaryCondition, std::ref(input),
-                  std::placeholders::_1),
-        stab_);
+    using Discretization = DivDGMaxDiscretization<DIM>;
+
+    {
+        std::map<std::size_t, typename Discretization::InputFunction>
+            elementVecs = {{Discretization::ELEMENT_SOURCE_VECTOR_ID,
+                            std::bind(&HarmonicProblem<DIM>::sourceTerm,
+                                      std::ref(input), std::placeholders::_1)}};
+        discretization_.computeElementIntegrands(mesh_, false, elementVecs);
+    }
+    {
+        std::map<std::size_t, typename Discretization::FaceInputFunction>
+            faceVecs = {{Discretization::FACE_BOUNDARY_VECTOR_ID,
+                         std::bind(&HarmonicProblem<DIM>::boundaryCondition,
+                                   std::ref(input), std::placeholders::_1)}};
+        discretization_.computeFaceIntegrals(mesh_, faceVecs, stab_);
+    }
 
     Utilities::GlobalIndexing indexing(&mesh_);
     Utilities::GlobalPetscMatrix massMatrix(
         indexing, DivDGMaxDiscretizationBase::ELEMENT_MASS_MATRIX_ID, -1),
-        stiffnessMatrix(
-            indexing, DivDGMaxDiscretizationBase::ELEMENT_STIFFNESS_MATRIX_ID,
-            DivDGMaxDiscretizationBase::FACE_STIFFNESS_MATRIX_ID);
+        stiffnessMatrix(indexing,
+                        DivDGMaxDiscretizationBase::ELEMENT_STIFFNESS_MATRIX_ID,
+                        DivDGMaxDiscretizationBase::FACE_STIFFNESS_MATRIX_ID);
     Utilities::GlobalPetscVector rhs(
         indexing, DivDGMaxDiscretizationBase::ELEMENT_SOURCE_VECTOR_ID,
         DivDGMaxDiscretizationBase::FACE_BOUNDARY_VECTOR_ID),
@@ -198,7 +204,7 @@ void DivDGMaxHarmonic<DIM>::writeTec(std::string fileName) const {
 
 template <std::size_t DIM>
 double DivDGMaxHarmonic<DIM>::computeL2Error(
-    const typename DivDGMaxDiscretization<DIM>::InputFunction& exactSolution){
+    const typename DivDGMaxDiscretization<DIM>::InputFunction& exactSolution) {
     return discretization_.computeL2Error(mesh_, 0, exactSolution);
 }
 

--- a/applications/DG-Max/Algorithms/DivDGMaxHarmonic.h
+++ b/applications/DG-Max/Algorithms/DivDGMaxHarmonic.h
@@ -53,7 +53,7 @@ class DivDGMaxHarmonic : public DGMax::AbstractHarmonicSolver<DIM> {
 
    public:
     DivDGMaxHarmonic(Base::MeshManipulator<DIM>& mesh,
-                     typename DivDGMaxDiscretization<DIM>::Stab stab,
+                     DivDGMaxDiscretizationBase::Stab stab,
                      std::size_t order);
 
     void solve(const HarmonicProblem<DIM>& input) final;
@@ -68,7 +68,7 @@ class DivDGMaxHarmonic : public DGMax::AbstractHarmonicSolver<DIM> {
    private:
     Base::MeshManipulator<DIM>& mesh_;
     DivDGMaxDiscretization<DIM> discretization_;
-    typename DivDGMaxDiscretization<DIM>::Stab stab_;
+    DivDGMaxDiscretizationBase::Stab stab_;
 };
 
 #endif  // HPGEM_APP_DIVDGMAXHARMONIC_H

--- a/applications/DG-Max/Algorithms/DivDGMaxHarmonic.h
+++ b/applications/DG-Max/Algorithms/DivDGMaxHarmonic.h
@@ -53,8 +53,7 @@ class DivDGMaxHarmonic : public DGMax::AbstractHarmonicSolver<DIM> {
 
    public:
     DivDGMaxHarmonic(Base::MeshManipulator<DIM>& mesh,
-                     DivDGMaxDiscretizationBase::Stab stab,
-                     std::size_t order);
+                     DivDGMaxDiscretizationBase::Stab stab, std::size_t order);
 
     void solve(const HarmonicProblem<DIM>& input) final;
     void writeTec(std::string fileName) const;

--- a/applications/DG-Max/Algorithms/DivDGMaxHarmonic.h
+++ b/applications/DG-Max/Algorithms/DivDGMaxHarmonic.h
@@ -62,8 +62,8 @@ class DivDGMaxHarmonic : public DGMax::AbstractHarmonicSolver<DIM> {
     // TODO: Error computation and tec-plot writing
     double computeL2Error(
         const typename DivDGMaxDiscretization<DIM>::InputFunction&
-            exactSolution) const;
-    double computeL2Error(const ExactHarmonicProblem<DIM>& problem) const;
+            exactSolution);
+    double computeL2Error(const ExactHarmonicProblem<DIM>& problem);
 
    private:
     Base::MeshManipulator<DIM>& mesh_;

--- a/applications/DG-Max/Programs/DGMaxEigen.cpp
+++ b/applications/DG-Max/Programs/DGMaxEigen.cpp
@@ -354,8 +354,7 @@ void runWithDimension() {
 
     // Method dependent solving
     if (useDivDGMax) {
-        DivDGMaxDiscretizationBase::Stab stab =
-            parsePenaltyParmaters();
+        DivDGMaxDiscretizationBase::Stab stab = parsePenaltyParmaters();
         DivDGMaxEigenvalue<DIM> solver(*mesh, order.getValue(), stab);
         solver.solve(driver);
     } else {

--- a/applications/DG-Max/Programs/DGMaxEigen.cpp
+++ b/applications/DG-Max/Programs/DGMaxEigen.cpp
@@ -78,8 +78,8 @@ auto& lengthScale = Base::register_argument<double>(
 template <std::size_t DIM>
 void runWithDimension();
 double parseDGMaxPenaltyParameter();
-template <std::size_t DIM>
-typename DivDGMaxDiscretization<DIM>::Stab parsePenaltyParmaters();
+
+DivDGMaxDiscretizationBase::Stab parsePenaltyParmaters();
 template <std::size_t DIM>
 KSpacePath<DIM> parsePath();
 
@@ -354,8 +354,8 @@ void runWithDimension() {
 
     // Method dependent solving
     if (useDivDGMax) {
-        typename DivDGMaxDiscretization<DIM>::Stab stab =
-            parsePenaltyParmaters<DIM>();
+        DivDGMaxDiscretizationBase::Stab stab =
+            parsePenaltyParmaters();
         DivDGMaxEigenvalue<DIM> solver(*mesh, order.getValue(), stab);
         solver.solve(driver);
     } else {
@@ -444,10 +444,9 @@ double parseDGMaxPenaltyParameter() {
     }
 }
 
-template <std::size_t DIM>
-typename DivDGMaxDiscretization<DIM>::Stab parsePenaltyParmaters() {
+DivDGMaxDiscretizationBase::Stab parsePenaltyParmaters() {
     if (pparams.isUsed()) {
-        typename DivDGMaxDiscretization<DIM>::Stab stab;
+        DivDGMaxDiscretizationBase::Stab stab;
         std::string input = pparams.getValue();
         std::vector<bool> useBrezzi;
         std::vector<double> values;
@@ -510,12 +509,12 @@ typename DivDGMaxDiscretization<DIM>::Stab parsePenaltyParmaters() {
             error = true;
         }
         if (!error) {
-            typename DivDGMaxDiscretization<DIM>::Stab result;
+            DivDGMaxDiscretizationBase::Stab result;
             result.stab1 = values[0];
             result.stab2 = values[1];
             result.stab3 = values[2];
 
-            using FLUX = typename DivDGMaxDiscretization<DIM>::FluxType;
+            using FLUX = DivDGMaxDiscretizationBase::FluxType;
 
             result.fluxType1 = useBrezzi[0] ? FLUX::BREZZI : FLUX::IP;
             result.fluxType2 = useBrezzi[1] ? FLUX::BREZZI : FLUX::IP;
@@ -527,11 +526,11 @@ typename DivDGMaxDiscretization<DIM>::Stab parsePenaltyParmaters() {
 
     } else {
         // Default values
-        typename DivDGMaxDiscretization<DIM>::Stab stab;
+        DivDGMaxDiscretizationBase::Stab stab;
         stab.stab1 = 5;
         stab.stab2 = 0;
         stab.stab3 = 5;
-        stab.setAllFluxeTypes(DivDGMaxDiscretization<DIM>::FluxType::BREZZI);
+        stab.setAllFluxeTypes(DivDGMaxDiscretizationBase::FluxType::BREZZI);
         return stab;
     }
 }

--- a/applications/DG-Max/Programs/DGMaxEigenConvergence.cpp
+++ b/applications/DG-Max/Programs/DGMaxEigenConvergence.cpp
@@ -135,7 +135,7 @@ void runWithDimension() {
             1, config, nullptr);
     } else if (method.getValue() == "DIVDGMAX") {
         // Some default stabilization parameters
-        typename DivDGMaxDiscretization<DIM>::Stab stab;
+        DivDGMaxDiscretizationBase::Stab stab;
         stab.stab1 = 5;
         stab.stab2 = 0;
         stab.stab3 = 5;

--- a/applications/DG-Max/Programs/DGMaxSource.cpp
+++ b/applications/DG-Max/Programs/DGMaxSource.cpp
@@ -156,7 +156,7 @@ void runWithDimension() {
 
     if (divdgmax) {
         // Placeholder for more complicate fluxes
-        typename DivDGMaxDiscretization<dim>::Stab stab;
+        DivDGMaxDiscretizationBase::Stab stab;
         stab.stab1 = 5;
         stab.stab2 = 0;
         stab.stab3 = 5;

--- a/applications/DG-Max/Utils/Verification/DivDGMaxEVConvergenceTest.h
+++ b/applications/DG-Max/Utils/Verification/DivDGMaxEVConvergenceTest.h
@@ -53,7 +53,7 @@ class DivDGMaxEVConvergenceTest : public AbstractEVConvergenceTest<DIM> {
     DivDGMaxEVConvergenceTest(EVTestPoint<DIM> testCase,
                               std::vector<std::string> meshFileNames,
                               double tolerance, std::size_t order,
-                              typename DivDGMaxDiscretization<DIM>::Stab stab,
+                              DivDGMaxDiscretizationBase::Stab stab,
                               EVConvergenceResult* expected)
         : testCase_(testCase),
           meshFileNames_(std::move(meshFileNames)),
@@ -87,7 +87,7 @@ class DivDGMaxEVConvergenceTest : public AbstractEVConvergenceTest<DIM> {
     std::vector<std::string> meshFileNames_;
     double tolerance_;
     std::size_t order_;
-    typename DivDGMaxDiscretization<DIM>::Stab stab_;
+    DivDGMaxDiscretizationBase::Stab stab_;
     // TODO: This is usually static data
     EVConvergenceResult* expected_;
 };

--- a/kernel/Base/PhysicalElement.h
+++ b/kernel/Base/PhysicalElement.h
@@ -205,7 +205,7 @@ class PhysicalElement final : public CoordinateTransformationData<DIM> {
 
     /// setters should only be needed internally
     void setTransformation(
-        std::shared_ptr<Base::CoordinateTransformation<DIM> > &transform,
+        std::shared_ptr<Base::CoordinateTransformation<DIM> > transform,
         std::size_t unknown = 0);
 
     /// setters should only be needed internally

--- a/kernel/Base/PhysicalElement_Impl.h
+++ b/kernel/Base/PhysicalElement_Impl.h
@@ -709,7 +709,7 @@ inline void PhysicalElement<DIM>::setElement(const Element* element) {
 
 template <std::size_t DIM>
 inline void PhysicalElement<DIM>::setTransformation(
-    std::shared_ptr<Base::CoordinateTransformation<DIM> >& transform,
+    std::shared_ptr<Base::CoordinateTransformation<DIM> > transform,
     std::size_t unknown) {
     if (transform_.size() <= unknown) {
         // We should not need to resize when we know the exact number of

--- a/kernel/Base/PhysicalFace.h
+++ b/kernel/Base/PhysicalFace.h
@@ -356,7 +356,7 @@ class PhysicalFace final {
 
     void setPointReference(const Geometry::PointReference<DIM - 1>& point);
     void setFace(const Face* face);
-    void setTransform(std::shared_ptr<CoordinateTransformation<DIM>>& transform,
+    void setTransform(std::shared_ptr<CoordinateTransformation<DIM>> transform,
                       std::size_t unknown = 0);
 
     void setQuadratureRule(QuadratureRules::GaussQuadratureRule* rule);

--- a/kernel/Base/PhysicalFace_Impl.h
+++ b/kernel/Base/PhysicalFace_Impl.h
@@ -933,7 +933,7 @@ inline void PhysicalFace<DIM>::setFace(const Face* face) {
 
 template <std::size_t DIM>
 inline void PhysicalFace<DIM>::setTransform(
-    std::shared_ptr<Base::CoordinateTransformation<DIM>>& transform,
+    std::shared_ptr<Base::CoordinateTransformation<DIM>> transform,
     std::size_t unknown) {
     if (transform_.size() <= unknown) {
         // We should not need to resize when we know the exact number of

--- a/kernel/Utilities/FaceLocalIndexing.h
+++ b/kernel/Utilities/FaceLocalIndexing.h
@@ -102,6 +102,26 @@ class FaceLocalIndexing {
         }
     }
 
+    /**
+     * For a given unknown, what are the indices in the face matrx.
+     * @param unknown The unkown
+     * @param mapping Mapping from the i-th DoF/basisFunction to the
+     * corresponding row/column in the face matrix.
+     */
+    void getDoFMapping(std::size_t unknown,
+                       std::vector<std::size_t>& mapping) const {
+        std::size_t leftOff = getDoFOffset(unknown, Base::Side::LEFT);
+        std::size_t leftCount = getNumberOfDoFs(unknown, Base::Side::LEFT);
+        std::size_t rightOff = getDoFOffset(unknown, Base::Side::RIGHT);
+        std::size_t rightCount = getNumberOfDoFs(unknown, Base::Side::RIGHT);
+
+        mapping.resize(leftCount + rightCount);
+        auto begin = mapping.begin();
+        auto endL = begin + leftCount;
+        std::iota(begin, endL, leftOff);
+        std::iota(endL, mapping.end(), rightOff);
+    }
+
     /// \return The total number of DoFs for all the included unknowns.
     std::size_t getNumberOfDoFs() const {
         return left_.getNumberOfDoFs() + right_.getNumberOfDoFs();

--- a/kernel/Utilities/FaceLocalIndexing.h
+++ b/kernel/Utilities/FaceLocalIndexing.h
@@ -112,14 +112,20 @@ class FaceLocalIndexing {
                        std::vector<std::size_t>& mapping) const {
         std::size_t leftOff = getDoFOffset(unknown, Base::Side::LEFT);
         std::size_t leftCount = getNumberOfDoFs(unknown, Base::Side::LEFT);
-        std::size_t rightOff = getDoFOffset(unknown, Base::Side::RIGHT);
-        std::size_t rightCount = getNumberOfDoFs(unknown, Base::Side::RIGHT);
+        if (right_.getElement() == nullptr) {
+            mapping.resize(leftCount);
+            std::iota(mapping.begin(), mapping.end(), leftOff);
+        } else {
+            std::size_t rightOff = getDoFOffset(unknown, Base::Side::RIGHT);
+            std::size_t rightCount =
+                getNumberOfDoFs(unknown, Base::Side::RIGHT);
 
-        mapping.resize(leftCount + rightCount);
-        auto begin = mapping.begin();
-        auto endL = begin + leftCount;
-        std::iota(begin, endL, leftOff);
-        std::iota(endL, mapping.end(), rightOff);
+            mapping.resize(leftCount + rightCount);
+            auto begin = mapping.begin();
+            auto endL = begin + leftCount;
+            std::iota(begin, endL, leftOff);
+            std::iota(endL, mapping.end(), rightOff);
+        }
     }
 
     /// \return The total number of DoFs for all the included unknowns.

--- a/kernel/Utilities/FaceLocalIndexing.h
+++ b/kernel/Utilities/FaceLocalIndexing.h
@@ -103,10 +103,11 @@ class FaceLocalIndexing {
     }
 
     /**
-     * For a given unknown, what are the indices in the face matrx.
-     * @param unknown The unkown
+     * For a given unknown, what are the indices in the face matrix.
+     * @param unknown The unknown
      * @param mapping Mapping from the i-th DoF/basisFunction to the
-     * corresponding row/column in the face matrix.
+     * corresponding row/column in the face matrix. Passed by reference to
+     * allow for reducing allocation.
      */
     void getDoFMapping(std::size_t unknown,
                        std::vector<std::size_t>& mapping) const {


### PR DESCRIPTION
I got frustrated with DivDGMaxDiscretization being far from elegant. This PR improves several parts.

The following things have been tackled:
 1. Reduce the number of integrators and transforms by sharing one set of them
 2. Extract a dimensionless base class for the discretization
 3. Move the code creating the element matrices inside a function.
 4. Replace the ~5 face integrands by 2, reducing the code duplication
 5. Remove excessive caching, this was recaching what was in PhysicalFace.
 6. Replace the way how input functions are passed to create element/face vectors
 7. Some minor type improvements.


Especially the face integrals of DivDGMaxDiscretization were significantly modified. The diff does not really look legible, split view might improve it, or otherwise look at the resulting functions without the original.
