### PR TITLE
Dgmax boundary conditions2

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -27,6 +27,6 @@ jobs:
     - name: make
       run: cmake --build build -- -j4
     - name: test
-      run: cd build && ctest
+      run: cd build && ctest --output-on-failure
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1

--- a/applications/DG-Max/Algorithms/DGMaxDiscretization.h
+++ b/applications/DG-Max/Algorithms/DGMaxDiscretization.h
@@ -129,8 +129,7 @@ class DGMaxDiscretization : public DGMaxDiscretizationBase {
         matrixHandling_ = matrixHandling;
     }
 
-    void setBoundaryIndicator(
-        DGMax::BoundaryConditionIndicator indicator) {
+    void setBoundaryIndicator(DGMax::BoundaryConditionIndicator indicator) {
         boundaryIndicator_ = indicator;
     }
 
@@ -203,7 +202,8 @@ class DGMaxDiscretization : public DGMaxDiscretizationBase {
     // The face vector integrand.
     void faceVector(Base::PhysicalFace<DIM>& fa,
                     const FaceInputFunction& boundaryCondition,
-                    LinearAlgebra::MiddleSizeVector& ret, double stab) const;
+                    LinearAlgebra::MiddleSizeVector& ret,
+                    DGMax::BoundaryConditionType bct, double stab) const;
 
     // TODO: Replace this by a better type than SmallVector<2>.
     LinearAlgebra::SmallVector<2> elementErrorIntegrand(

--- a/applications/DG-Max/Algorithms/DGMaxDiscretization.h
+++ b/applications/DG-Max/Algorithms/DGMaxDiscretization.h
@@ -52,6 +52,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "Geometry/PointPhysical.h"
 #include "Integration/ElementIntegral.h"
 #include "Integration/FaceIntegral.h"
+#include "ProblemTypes/BoundaryConditionType.h"
 
 using namespace hpgem;
 
@@ -126,6 +127,11 @@ class DGMaxDiscretization : public DGMaxDiscretizationBase {
 
     void setMatrixHandling(MassMatrixHandling matrixHandling) {
         matrixHandling_ = matrixHandling;
+    }
+
+    void setBoundaryIndicator(
+        DGMax::BoundaryConditionIndicator indicator) {
+        boundaryIndicator_ = indicator;
     }
 
     void initializeBasisFunctions(Base::MeshManipulator<DIM>& mesh,
@@ -210,6 +216,7 @@ class DGMaxDiscretization : public DGMaxDiscretizationBase {
 
     const bool includeProjector_;
     MassMatrixHandling matrixHandling_;
+    DGMax::BoundaryConditionIndicator boundaryIndicator_;
 
     std::vector<std::shared_ptr<Base::CoordinateTransformation<DIM>>>
         transforms_;

--- a/applications/DG-Max/Algorithms/DGMaxHarmonic.cpp
+++ b/applications/DG-Max/Algorithms/DGMaxHarmonic.cpp
@@ -66,6 +66,10 @@ void DGMaxHarmonic<DIM>::solve(const HarmonicProblem<DIM>& harmonicProblem) {
                   std::placeholders::_1);
 
     discretization.setMatrixHandling(DGMaxDiscretizationBase::NORMAL);
+    discretization.setBoundaryIndicator(
+        std::bind(&HarmonicProblem<DIM>::getBoundaryConditionType,
+                  &harmonicProblem, std::placeholders::_1));
+
     discretization.computeElementIntegrands(mesh_, elementVectors);
 
     std::map<std::size_t, typename DGMaxDiscretization<DIM>::FaceInputFunction>

--- a/applications/DG-Max/Algorithms/DivDGMaxDiscretization.cpp
+++ b/applications/DG-Max/Algorithms/DivDGMaxDiscretization.cpp
@@ -234,9 +234,6 @@ void DivDGMaxDiscretization<DIM>::computeFaceIntegrals(
                                                     stab);
                 }
             }
-            if (bct == DGMax::BoundaryConditionType::NEUMANN) {
-                logger(INFO, "Vec %", vec);
-            }
             face->setFaceVector(vec, boundaryVec.first);
         }
     }

--- a/applications/DG-Max/Algorithms/DivDGMaxDiscretization.cpp
+++ b/applications/DG-Max/Algorithms/DivDGMaxDiscretization.cpp
@@ -206,8 +206,6 @@ void DivDGMaxDiscretization<DIM>::computeFaceIntegrals(
                 if (bct != BCT::NEUMANN) {
                     faceStiffnessMatrixFieldIntegrand(face, indexing, stab,
                                                       result);
-                } else {
-                    // TODO: Add impedance integral
                 }
                 addFaceMatrixPotentialIntegrand(face, indexing, stab, bct,
                                                 result);

--- a/applications/DG-Max/Algorithms/DivDGMaxDiscretization.h
+++ b/applications/DG-Max/Algorithms/DivDGMaxDiscretization.h
@@ -48,6 +48,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "Integration/ElementIntegral.h"
 #include "Integration/FaceIntegral.h"
 
+#include "ProblemTypes/BoundaryConditionType.h"
+
+
 // Forward definitions
 namespace hpgem {
 namespace Base {
@@ -152,6 +155,10 @@ class DivDGMaxDiscretization : public DivDGMaxDiscretizationBase {
 
     void initializeBasisFunctions(Base::MeshManipulator<DIM>& mesh,
                                   std::size_t order);
+
+    void setBoundaryIndicator(DGMax::BoundaryConditionIndicator indicator) {
+        boundaryIndicator_ = indicator;
+    }
 
     void computeElementIntegrands(
         Base::MeshManipulator<DIM>& mesh,
@@ -306,6 +313,8 @@ class DivDGMaxDiscretization : public DivDGMaxDiscretizationBase {
     Integration::FaceIntegral<DIM> faceIntegrator_;
     std::shared_ptr<Base::HCurlConformingTransformation<DIM>> fieldTransform_;
     std::shared_ptr<Base::H1ConformingTransformation<DIM>> potentialTransform_;
+
+    DGMax::BoundaryConditionIndicator boundaryIndicator_;
 };
 
 // TODO: Deduction fails for a templated variant, hence using explicit versions

--- a/applications/DG-Max/Algorithms/DivDGMaxDiscretization.h
+++ b/applications/DG-Max/Algorithms/DivDGMaxDiscretization.h
@@ -50,7 +50,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "ProblemTypes/BoundaryConditionType.h"
 
-
 // Forward definitions
 namespace hpgem {
 namespace Base {
@@ -225,9 +224,8 @@ class DivDGMaxDiscretization : public DivDGMaxDiscretizationBase {
         DGMax::BoundaryConditionType bct,
         LinearAlgebra::MiddleSizeMatrix& ret) const;
 
-    LinearAlgebra::MiddleSizeMatrix brezziFluxBilinearTerm(Base::Face* face,
-                                                           DGMax::BoundaryConditionType bct,
-                                                           Stab stab);
+    LinearAlgebra::MiddleSizeMatrix brezziFluxBilinearTerm(
+        Base::Face* face, DGMax::BoundaryConditionType bct, Stab stab);
 
     /// \brief Compute mass matrix for vector components on elements adjacent to
     /// a face
@@ -299,8 +297,7 @@ class DivDGMaxDiscretization : public DivDGMaxDiscretizationBase {
     void faceBoundaryVector(Base::PhysicalFace<DIM>& fa,
                             const FaceInputFunction& boundaryValue,
                             LinearAlgebra::MiddleSizeVector& ret,
-                            DGMax::BoundaryConditionType bct,
-                            Stab stab) const;
+                            DGMax::BoundaryConditionType bct, Stab stab) const;
 
     /// Compute contribution of the brezzi flux to the face vector on the
     /// boundary

--- a/applications/DG-Max/Algorithms/DivDGMaxDiscretization.h
+++ b/applications/DG-Max/Algorithms/DivDGMaxDiscretization.h
@@ -155,6 +155,7 @@ class DivDGMaxDiscretization : public DivDGMaxDiscretizationBase {
     void initializeBasisFunctions(Base::MeshManipulator<DIM>& mesh,
                                   std::size_t order);
 
+    /// Set the indicator function for the boundary condition to use
     void setBoundaryIndicator(DGMax::BoundaryConditionIndicator indicator) {
         boundaryIndicator_ = indicator;
     }

--- a/applications/DG-Max/Algorithms/DivDGMaxDiscretization.h
+++ b/applications/DG-Max/Algorithms/DivDGMaxDiscretization.h
@@ -222,9 +222,11 @@ class DivDGMaxDiscretization : public DivDGMaxDiscretizationBase {
     void addFaceMatrixPotentialIntegrand(
         Base::PhysicalFace<DIM>& fa,
         const Utilities::FaceLocalIndexing& indexing, const Stab& stab,
+        DGMax::BoundaryConditionType bct,
         LinearAlgebra::MiddleSizeMatrix& ret) const;
 
     LinearAlgebra::MiddleSizeMatrix brezziFluxBilinearTerm(Base::Face* face,
+                                                           DGMax::BoundaryConditionType bct,
                                                            Stab stab);
 
     /// \brief Compute mass matrix for vector components on elements adjacent to
@@ -297,6 +299,7 @@ class DivDGMaxDiscretization : public DivDGMaxDiscretizationBase {
     void faceBoundaryVector(Base::PhysicalFace<DIM>& fa,
                             const FaceInputFunction& boundaryValue,
                             LinearAlgebra::MiddleSizeVector& ret,
+                            DGMax::BoundaryConditionType bct,
                             Stab stab) const;
 
     /// Compute contribution of the brezzi flux to the face vector on the

--- a/applications/DG-Max/Algorithms/DivDGMaxHarmonic.cpp
+++ b/applications/DG-Max/Algorithms/DivDGMaxHarmonic.cpp
@@ -129,10 +129,12 @@ void DivDGMaxHarmonic<DIM>::solve(const HarmonicProblem<DIM>& input) {
         KSPGetConvergedReasonString(solver, &convergedReason);
         if (converged > 0) {
             // Successful
-            DGMaxLogger(INFO, "Successfully converged in % iterations with reason %",
+            DGMaxLogger(INFO,
+                        "Successfully converged in % iterations with reason %",
                         niters, convergedReason);
         } else {
-            DGMaxLogger(WARN, "Failed to converge in % iterations with reason %",
+            DGMaxLogger(WARN,
+                        "Failed to converge in % iterations with reason %",
                         niters, convergedReason);
         }
     }

--- a/applications/DG-Max/Algorithms/DivDGMaxHarmonic.cpp
+++ b/applications/DG-Max/Algorithms/DivDGMaxHarmonic.cpp
@@ -126,7 +126,13 @@ void DivDGMaxHarmonic<DIM>::solve(const HarmonicProblem<DIM>& input) {
         KSPConvergedReason converged;
         KSPGetConvergedReason(solver, &converged);
         const char* convergedReason;
+
+#if PETSC_VERSION_GE(3, 15, 0)
         KSPGetConvergedReasonString(solver, &convergedReason);
+#else
+        convergedReason = KSPConvergedReasons[converged];
+#endif
+
         if (converged > 0) {
             // Successful
             DGMaxLogger(INFO,

--- a/applications/DG-Max/Algorithms/DivDGMaxHarmonic.cpp
+++ b/applications/DG-Max/Algorithms/DivDGMaxHarmonic.cpp
@@ -58,9 +58,11 @@ DivDGMaxHarmonic<DIM>::DivDGMaxHarmonic(Base::MeshManipulator<DIM>& mesh,
 template <std::size_t DIM>
 void DivDGMaxHarmonic<DIM>::solve(const HarmonicProblem<DIM>& input) {
     PetscErrorCode error;
-
     using Discretization = DivDGMaxDiscretization<DIM>;
 
+    discretization_.setBoundaryIndicator(
+        std::bind(&HarmonicProblem<DIM>::getBoundaryConditionType, &input,
+                  std::placeholders::_1));
     {
         std::map<std::size_t, typename Discretization::InputFunction>
             elementVecs = {{Discretization::ELEMENT_SOURCE_VECTOR_ID,

--- a/applications/DG-Max/ProblemTypes/BoundaryConditionType.h
+++ b/applications/DG-Max/ProblemTypes/BoundaryConditionType.h
@@ -1,0 +1,76 @@
+/*
+ This file forms part of hpGEM. This package has been developed over a number of
+ years by various people at the University of Twente and a full list of
+ contributors can be found at http://hpgem.org/about-the-code/team
+
+ This code is distributed using BSD 3-Clause License. A copy of which can found
+ below.
+
+
+ Copyright (c) 2021, University of Twente
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation
+ and/or other materials provided with the distribution.
+
+ 3. Neither the name of the copyright holder nor the names of its contributors
+ may be used to endorse or promote products derived from this software without
+ specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef HPGEM_BOUNDARYCONDITIONTYPE_H
+#define HPGEM_BOUNDARYCONDITIONTYPE_H
+
+#include <functional>
+#include "Base/Face.h"
+
+namespace DGMax {
+
+/**
+ * Enumeration of the possible boundary conditions that could be used on a
+ * boundary face.
+ *
+ * Note: Not all boundary conditions may be supported by all algorithms.
+ */
+enum class BoundaryConditionType {
+    /**
+     * Boundary condition of the form n x E = n x g, thus prescribing the
+     * tangential part of the field on the boundary face.
+     */
+    DIRICHLET,
+    /**
+     * Boundary condition of the form n x (curl E) = n x g, thus prescribing the
+     * tangential part of the curl on the boundary face.
+     */
+    NEUMANN,
+    /**
+     * Dummy value for internal faces, should not be used for external faces.
+     *
+     * This is primarily intended so that we can assign each face a value
+     */
+    INTERNAL,
+};
+
+using BoundaryConditionIndicator = typename std::function<BoundaryConditionType(
+    const hpgem::Base::Face&)>;
+
+}  // namespace DGMax
+
+#endif  // HPGEM_BOUNDARYCONDITIONTYPE_H

--- a/applications/DG-Max/ProblemTypes/BoundaryConditionType.h
+++ b/applications/DG-Max/ProblemTypes/BoundaryConditionType.h
@@ -51,12 +51,12 @@ namespace DGMax {
  */
 enum class BoundaryConditionType {
     /**
-     * Boundary condition of the form n x E = n x g, thus prescribing the
+     * Boundary condition of the form n x E = n x g_D, thus prescribing the
      * tangential part of the field on the boundary face.
      */
     DIRICHLET,
     /**
-     * Boundary condition of the form n x (curl E) = n x g, thus prescribing the
+     * Boundary condition of the form n x (curl E) = n x g_N, thus prescribing the
      * tangential part of the curl on the boundary face.
      */
     NEUMANN,

--- a/applications/DG-Max/ProblemTypes/BoundaryConditionType.h
+++ b/applications/DG-Max/ProblemTypes/BoundaryConditionType.h
@@ -56,8 +56,8 @@ enum class BoundaryConditionType {
      */
     DIRICHLET,
     /**
-     * Boundary condition of the form n x (curl E) = n x g_N, thus prescribing the
-     * tangential part of the curl on the boundary face.
+     * Boundary condition of the form n x (curl E) = n x g_N, thus prescribing
+     * the tangential part of the curl on the boundary face.
      */
     NEUMANN,
     /**
@@ -68,8 +68,8 @@ enum class BoundaryConditionType {
     INTERNAL,
 };
 
-using BoundaryConditionIndicator = typename std::function<BoundaryConditionType(
-    const hpgem::Base::Face&)>;
+using BoundaryConditionIndicator =
+    typename std::function<BoundaryConditionType(const hpgem::Base::Face&)>;
 
 }  // namespace DGMax
 

--- a/applications/DG-Max/ProblemTypes/Harmonic/SampleHarmonicProblems.h
+++ b/applications/DG-Max/ProblemTypes/Harmonic/SampleHarmonicProblems.h
@@ -63,6 +63,12 @@ class SampleHarmonicProblems : public ExactHarmonicProblem<DIM> {
     LinearAlgebra::SmallVector<DIM> exactSolutionCurl(
         const Geometry::PointPhysical<DIM>& point) const override;
 
+    // Historical implementation
+    DGMax::BoundaryConditionType getBoundaryConditionType(
+        const Base::Face& face) const override {
+        return DGMax::BoundaryConditionType::DIRICHLET;
+    }
+
    private:
     const Problem problem_;
     const double omega_;

--- a/applications/DG-Max/ProblemTypes/HarmonicProblem.h
+++ b/applications/DG-Max/ProblemTypes/HarmonicProblem.h
@@ -42,6 +42,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "Geometry/PointPhysical.h"
 #include "Base/PhysicalFace.h"
 #include "LinearAlgebra/SmallVector.h"
+#include "BoundaryConditionType.h"
 
 using namespace hpgem;
 
@@ -69,6 +70,8 @@ class HarmonicProblem {
         const Geometry::PointPhysical<DIM>& point) const = 0;
     virtual LinearAlgebra::SmallVector<DIM> boundaryCondition(
         Base::PhysicalFace<DIM>& face) const = 0;
+    virtual DGMax::BoundaryConditionType getBoundaryConditionType(
+        const Base::Face& face) const = 0;
 };
 
 template <std::size_t DIM>
@@ -86,6 +89,12 @@ class ExactHarmonicProblem : public HarmonicProblem<DIM> {
         const LinearAlgebra::SmallVector<DIM>& normal =
             face.getUnitNormalVector();
         return normal.crossProduct(efield);
+    }
+
+    // Implementation to match boundaryCondition implementation
+    DGMax::BoundaryConditionType getBoundaryConditionType(
+        const Base::Face& face) const final {
+        return DGMax::BoundaryConditionType::DIRICHLET;
     }
 };
 

--- a/applications/DG-Max/ProblemTypes/HarmonicProblem.h
+++ b/applications/DG-Max/ProblemTypes/HarmonicProblem.h
@@ -68,10 +68,22 @@ class HarmonicProblem {
     virtual double omega() const = 0;
     virtual LinearAlgebra::SmallVector<DIM> sourceTerm(
         const Geometry::PointPhysical<DIM>& point) const = 0;
-    virtual LinearAlgebra::SmallVector<DIM> boundaryCondition(
-        Base::PhysicalFace<DIM>& face) const = 0;
     virtual DGMax::BoundaryConditionType getBoundaryConditionType(
         const Base::Face& face) const = 0;
+
+    /**
+     * Value of the boundary function. The use of this value depends on
+     * getBoundaryConditionType(). For the different boundary conditions this
+     * should be:
+     *
+     * - Dirichlet: n x g_D (TODO: Future refactor -> g_D)
+     * - Neumann: g_N
+     *
+     * @param face The face and point to evaluate the BC on
+     * @return The value.
+     */
+    virtual LinearAlgebra::SmallVector<DIM> boundaryCondition(
+        Base::PhysicalFace<DIM>& face) const = 0;
 };
 
 template <std::size_t DIM>
@@ -84,17 +96,23 @@ class ExactHarmonicProblem : public HarmonicProblem<DIM> {
 
     LinearAlgebra::SmallVector<DIM> boundaryCondition(
         Base::PhysicalFace<DIM>& face) const final {
-        LinearAlgebra::SmallVector<DIM> efield =
-            exactSolution(face.getPointPhysical());
-        const LinearAlgebra::SmallVector<DIM>& normal =
-            face.getUnitNormalVector();
-        return normal.crossProduct(efield);
-    }
 
-    // Implementation to match boundaryCondition implementation
-    DGMax::BoundaryConditionType getBoundaryConditionType(
-        const Base::Face& face) const final {
-        return DGMax::BoundaryConditionType::DIRICHLET;
+        using BCT = DGMax::BoundaryConditionType;
+        using Vec = LinearAlgebra::SmallVector<DIM>;
+        BCT bct = this->getBoundaryConditionType(*face.getFace());
+        switch (bct) {
+            case BCT::DIRICHLET: {
+                Vec efield = this->exactSolution(face.getPointPhysical());
+                Vec normal = face.getUnitNormalVector();
+                return normal.crossProduct(efield);
+            }
+            case BCT::NEUMANN:
+                return this->exactSolutionCurl(face.getPointPhysical());
+            default:
+                logger(ERROR,
+                       "Not implemented for this type of boundary condition.");
+                return {};
+        }
     }
 };
 

--- a/applications/DG-Max/Programs/DGMaxSource.cpp
+++ b/applications/DG-Max/Programs/DGMaxSource.cpp
@@ -108,7 +108,7 @@ template <std::size_t dim>
 class TestingProblem : public HarmonicProblem<dim> {
 
    public:
-    TestingProblem() : pface(false){};
+    TestingProblem(){};
 
     double omega() const final { return 4.0e-2; }
 
@@ -129,13 +129,14 @@ class TestingProblem : public HarmonicProblem<dim> {
 
     DGMax::BoundaryConditionType getBoundaryConditionType(
         const Base::Face& face) const final {
-        pface.setFace(&face);
-        pface.setPointReference(face.getReferenceGeometry()->getCenter());
+
         if (face.isInternal()) {
             return DGMax::BoundaryConditionType::INTERNAL;
         }
 
-        LinearAlgebra::SmallVector<dim> normal = pface.getUnitNormalVector();
+        LinearAlgebra::SmallVector<dim> normal = face.getNormalVector(
+            face.getReferenceGeometry()->getCenter().castDimension<dim - 1>());
+        normal /= normal.l2Norm();
 
         double nx = std::abs(std::abs(normal[0]) - 1.0);
         if (nx < 1e-8) {
@@ -144,9 +145,6 @@ class TestingProblem : public HarmonicProblem<dim> {
             return DGMax::BoundaryConditionType::NEUMANN;
         }
     }
-
-   private:
-    mutable Base::PhysicalFace<dim> pface;
 };
 
 template <std::size_t dim>

--- a/applications/DG-Max/Programs/DGMaxSource.cpp
+++ b/applications/DG-Max/Programs/DGMaxSource.cpp
@@ -139,9 +139,9 @@ class TestingProblem : public HarmonicProblem<dim> {
 
         double nx = std::abs(std::abs(normal[0]) - 1.0);
         if (nx < 1e-8) {
-            return DGMax::BoundaryConditionType::NEUMANN;
-        } else {
             return DGMax::BoundaryConditionType::DIRICHLET;
+        } else {
+            return DGMax::BoundaryConditionType::NEUMANN;
         }
     }
 

--- a/applications/DG-Max/Programs/DGMaxSource.cpp
+++ b/applications/DG-Max/Programs/DGMaxSource.cpp
@@ -138,10 +138,13 @@ class TestingProblem : public HarmonicProblem<dim> {
             face.getReferenceGeometry()->getCenter().castDimension<dim - 1>());
         normal /= normal.l2Norm();
 
+        // Check if the normal matches: {1,0} or {-1,0}
         double nx = std::abs(std::abs(normal[0]) - 1.0);
         if (nx < 1e-8) {
+            // For faces at y=0,1
             return DGMax::BoundaryConditionType::DIRICHLET;
         } else {
+            // For faces at x=0,1
             return DGMax::BoundaryConditionType::NEUMANN;
         }
     }

--- a/kernel/Utilities/GlobalVector.cpp
+++ b/kernel/Utilities/GlobalVector.cpp
@@ -459,6 +459,21 @@ void GlobalPetscVector::writeTimeIntegrationVector(
     VecDestroy(&localB);
     CHKERRV(ierr);
 }
+
+void GlobalPetscVector::writeMatlab(Vec vec, const std::string& fileName) {
+    PetscViewer viewer;
+    PetscErrorCode err;
+
+    err = PetscViewerASCIIOpen(PETSC_COMM_WORLD, fileName.c_str(), &viewer);
+    CHKERRABORT(PETSC_COMM_WORLD, err);
+    err = PetscViewerPushFormat(viewer, PETSC_VIEWER_ASCII_MATLAB);
+    CHKERRABORT(PETSC_COMM_WORLD, err);
+    err = VecView(vec, viewer);
+    CHKERRABORT(PETSC_COMM_WORLD, err);
+    err = PetscViewerDestroy(&viewer);
+    CHKERRABORT(PETSC_COMM_WORLD, err);
+}
+
 #endif
 
 }  // namespace Utilities

--- a/kernel/Utilities/GlobalVector.h
+++ b/kernel/Utilities/GlobalVector.h
@@ -147,6 +147,11 @@ class GlobalPetscVector : public GlobalVector {
 
     void assemble() override;
 
+    void writeMatlab(const std::string& fileName) {
+        writeMatlab(b_, fileName);
+    };
+    static void writeMatlab(Vec vec, const std::string& fileName);
+
    private:
     void createVec();
     void zeroVector();

--- a/tests/self/ConvergenceTest.h
+++ b/tests/self/ConvergenceTest.h
@@ -40,8 +40,10 @@
 
 #include "Logger.h"
 
-#include "string"
-#include "iomanip"
+#include <iomanip>
+#include <iostream>
+#include <string>
+#include <vector>
 
 namespace hpgem {
 

--- a/tests/self/ConvergenceTest.h
+++ b/tests/self/ConvergenceTest.h
@@ -40,6 +40,7 @@
 
 #include "Logger.h"
 
+#include <cmath>
 #include <iomanip>
 #include <iostream>
 #include <string>

--- a/tests/self/DGMax/DGMax_PlaneWave_SelfTest.cpp
+++ b/tests/self/DGMax/DGMax_PlaneWave_SelfTest.cpp
@@ -169,7 +169,8 @@ int main(int argc, char** argv) {
 
     // Default the solver if not specified to a direct LU solver
     std::map<std::string, std::string> defaultOptions = {
-        {"-ksp_type", "preonly"}, {"-pc_type", "lu"},
+        {"-ksp_type", "preonly"},
+        {"-pc_type", "lu"},
         // The DivDGMax system can't be solved with the petsc solver
         {"-pc_factor_mat_solver_type", "umfpack"}};
     for (const auto& option : defaultOptions) {

--- a/tests/self/DGMax/DGMax_PlaneWave_SelfTest.cpp
+++ b/tests/self/DGMax/DGMax_PlaneWave_SelfTest.cpp
@@ -182,7 +182,14 @@ int main(int argc, char** argv) {
                                      2.17527652e-04,  //  3.98
                                      5.45037524e-05,  //  3.99
                                  }};
-    runConvergenceTest(meshes, ignoreFailures, &solve);
-    ConvergenceTestSet meshes2 = {getUnitSquareTriangleMeshes(0, 5), {}};
+    runConvergenceTest(meshes, ignoreFailures, &solveDGMax);
+    ConvergenceTestSet meshes2 = {getUnitSquareTriangleMeshes(0, 5),
+                                  {
+                                      1.59795098e-01,  //------
+                                      4.93777108e-02,  //  3.24
+                                      1.17391078e-02,  //  4.21
+                                      2.92095459e-03,  //  4.02
+                                      7.30300125e-04,  //  4.00
+                                  }};
     runConvergenceTest(meshes2, ignoreFailures, &solveDivDGMax);
 }

--- a/tests/self/DGMax/DGMax_PlaneWave_SelfTest.cpp
+++ b/tests/self/DGMax/DGMax_PlaneWave_SelfTest.cpp
@@ -63,7 +63,10 @@ class TestingProblem : public ExactHarmonicProblem<2> {
         //     are the normal directions in the mesh.
         : k_({1 * M_PI, 0.5 * M_PI}), E0_({0.5, -1}), bface(false){};
 
-    double omega() const final { return 3.0; }
+    double omega() const final {
+        // Off resonance so that we need a source term and test that as well.
+        return 3.0;
+    }
 
     double modulation(const Point& p) const {
         return std::cos(p.getCoordinates() * k_);

--- a/tests/self/DGMax/DGMax_PlaneWave_SelfTest.cpp
+++ b/tests/self/DGMax/DGMax_PlaneWave_SelfTest.cpp
@@ -169,7 +169,9 @@ int main(int argc, char** argv) {
 
     // Default the solver if not specified to a direct LU solver
     std::map<std::string, std::string> defaultOptions = {
-        {"-ksp_type", "preonly"}, {"-pc_type", "lu"}};
+        {"-ksp_type", "preonly"}, {"-pc_type", "lu"},
+        // The DivDGMax system can't be solved with the petsc solver
+        {"-pc_factor_mat_solver_type", "umfpack"}};
     for (const auto& option : defaultOptions) {
         PetscBool present;
         PetscOptionsHasName(nullptr, nullptr, option.first.c_str(), &present);
@@ -198,7 +200,7 @@ int main(int argc, char** argv) {
                                       4.98064965e-02,  //  3.67
                                       1.20771131e-02,  //  4.12
                                       2.97631344e-03,  //  4.06
-                                      7.37982121e-04,  //  4.03
+                                      7.37982120e-04,  //  4.03
                                   }};
     runConvergenceTest(meshes2, ignoreFailures, &solveDivDGMax);
 }

--- a/tests/self/DGMax/DGMax_PlaneWave_SelfTest.cpp
+++ b/tests/self/DGMax/DGMax_PlaneWave_SelfTest.cpp
@@ -1,0 +1,158 @@
+/*
+ This file forms part of hpGEM. This package has been developed over a number of
+ years by various people at the University of Twente and a full list of
+ contributors can be found at http://hpgem.org/about-the-code/team
+
+ This code is distributed using BSD 3-Clause License. A copy of which can found
+ below.
+
+
+ Copyright (c) 2021, University of Twente
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation
+ and/or other materials provided with the distribution.
+
+ 3. Neither the name of the copyright holder nor the names of its contributors
+ may be used to endorse or promote products derived from this software without
+ specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "../ConvergenceTest.h"
+#include "../TestMeshes.h"
+
+#include <Base/CommandLineOptions.h>
+#include <DGMaxProgramUtils.h>
+#include <DGMaxLogger.h>
+#include <Algorithms/DGMaxHarmonic.h>
+#include <Utils/PredefinedStructure.h>
+
+#include <petsc.h>
+
+using namespace DGMax;
+
+using Vec2 = LinearAlgebra::SmallVector<2>;
+using Point = Geometry::PointPhysical<2>;
+
+class TestingProblem : public ExactHarmonicProblem<2> {
+   public:
+    TestingProblem()
+        // k_ is choosen such that:
+        //  1. Not too small, as that would only show the linear part
+        //  2. Not too large, as multiple period will only converge on very
+        //     finer meshes.
+        //  3. Not in the cardinal directions or along the diagonals, as those
+        //     are the normal directions in the mesh.
+        : k_({1 * M_PI, 0.5 * M_PI}), E0_({0.5, -1}), bface(false){};
+
+    double omega() const final { return 3.0; }
+
+    double modulation(const Point& p) const {
+        return std::cos(p.getCoordinates() * k_);
+    }
+
+    Vec2 sourceTerm(const Point& p) const final {
+        double omega2 = omega();
+        omega2 *= omega2;
+        return E0_ * modulation(p) * (k_.l2NormSquared() - omega2);
+    }
+    Vec2 exactSolution(const Point& p) const final {
+        return E0_ * modulation(p);
+    }
+    Vec2 exactSolutionCurl(const Point& p) const final {
+        return -k_.crossProduct(E0_) * std::sin(p.getCoordinates() * k_);
+    }
+
+    BoundaryConditionType getBoundaryConditionType(
+        const Base::Face& face) const final {
+
+        bface.setFace(&face);
+        bface.setPointReference(face.getReferenceGeometry()->getCenter());
+        Vec2 normal = bface.getUnitNormalVector();
+        double nx = std::abs(normal[0]);
+        if (std::abs(nx - 1.0) < 1e-8) {
+            return BoundaryConditionType::NEUMANN;
+        } else {
+            return BoundaryConditionType::NEUMANN;
+        }
+    }
+
+   private:
+    Vec2 k_;
+    /// Direction of the field
+    Vec2 E0_;
+    /// Used for computing the boundary condition type
+    mutable Base::PhysicalFace<2> bface;
+};
+
+double solve(std::string meshFile, std::size_t level) {
+    Base::ConfigurationData config(1);
+
+    PredefinedStructureDescription structure =
+        PredefinedStructureDescription(PredefinedStructure::VACUUM, 2);
+
+    auto mesh = DGMax::readMesh<2>(meshFile, &config, structure, 2);
+    DGMaxHarmonic<2> solver(*mesh, 100, 2);
+
+    TestingProblem problem;
+
+    solver.solve(problem);
+    std::stringstream fileName;
+    fileName << "solution-" << level;
+    Output::VTKSpecificTimeWriter<2> output(fileName.str(), mesh.get(), 0, 2);
+    solver.writeVTK(output);
+    auto errors = solver.computeError({DGMaxDiscretizationBase::L2}, problem);
+    return errors[DGMaxDiscretizationBase::L2];
+}
+
+int main(int argc, char** argv) {
+
+    Base::parse_options(argc, argv);
+    initDGMaxLogging();
+
+    bool ignoreFailures = false;
+
+    // Default the solver if not specified to a direct LU solver
+    std::map<std::string, std::string> defaultOptions = {
+        {"-ksp_type", "preonly"}, {"-pc_type", "lu"}};
+    for (const auto& option : defaultOptions) {
+        PetscBool present;
+        PetscOptionsHasName(nullptr, nullptr, option.first.c_str(), &present);
+        if (!present) {
+            PetscOptionsSetValue(nullptr, option.first.c_str(),
+                                 option.second.c_str());
+        }
+    }
+
+    // Using second order Nedelec basis functions. So convergence rate for the
+    // L2 norm is expected at h^{p} => reduction of a factor 4 with each level
+    ConvergenceTestSet meshes = {getUnitSquareTriangleMeshes(),
+                                 {
+                                     1.42329582e-01,  //------
+                                     5.25619738e-02,  //  2.71
+                                     1.34616005e-02,  //  3.90
+                                     3.43157573e-03,  //  3.92
+                                     8.66123561e-04,  //  3.96
+                                     2.17527652e-04,  //  3.98
+                                     5.45037524e-05,  //  3.99
+                                 }};
+    runConvergenceTest(meshes, ignoreFailures, &solve);
+}


### PR DESCRIPTION
Adds a different type of boundary condition to (Div)DGMax. The previous code only allowed specifying the transverse part of the electric field (Dirichlet-style boundary condition). This PR changes adds the option to specify the transverse part of the magnatic field (= curl of electric field), which is a Neumann-style boundary condition.

Review recommendation:
First review
 - `BoundaryConditionType` giving a description of the boundary conditions
 -  `HarmonicProblem` the class that specifies which boundary condition should be used