### PR TITLE
Complex smallvector

### DIFF
--- a/applications/DG-Max/Algorithms/DivDGMaxDiscretization.h
+++ b/applications/DG-Max/Algorithms/DivDGMaxDiscretization.h
@@ -48,6 +48,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "Integration/ElementIntegral.h"
 #include "Integration/FaceIntegral.h"
 
+#include "LinearAlgebra/MiddleSizeMatrix.h"
+#include "LinearAlgebra/MiddleSizeVector.h"
+#include "LinearAlgebra/SmallVector.h"
+
 // Forward definitions
 namespace hpgem {
 namespace Base {
@@ -56,14 +60,6 @@ class PhysicalElement;
 template <std::size_t DIM>
 class PhysicalFace;
 }  // namespace Base
-
-namespace LinearAlgebra {
-class MiddleSizeMatrix;
-class MiddleSizeVector;
-
-template <std::size_t DIM>
-class SmallVector;
-}  // namespace LinearAlgebra
 
 namespace Utilities {
 class ElementLocalIndexing;

--- a/kernel/FE/BasisFunctionSet.h
+++ b/kernel/FE/BasisFunctionSet.h
@@ -43,12 +43,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "Logger.h"
 #include "BaseBasisFunction.h"
 namespace hpgem {
-namespace LinearAlgebra {
-template <std::size_t DIM>
-class SmallVector;
-}
-
 namespace Geometry {
+
 template <std::size_t DIM>
 class PointReference;
 

--- a/kernel/Geometry/ReferenceSimplex.h
+++ b/kernel/Geometry/ReferenceSimplex.h
@@ -6,13 +6,8 @@
 #include "ReferenceGeometry.h"
 
 namespace hpgem {
-
-namespace LinearAlgebra {
-template <std::size_t DIM>
-class SmallVector;
-}
-
 namespace Geometry {
+
 /// Implementation of a reference simplex (triangle, tetrahedron)
 ///
 /// The standard reference simplex is formed by the origin and each of the

--- a/kernel/LinearAlgebra/CMakeLists.txt
+++ b/kernel/LinearAlgebra/CMakeLists.txt
@@ -2,7 +2,8 @@ include_directories(${hpGEM_SOURCE_DIR}/kernel/ .)
 
 add_library(LinearAlgebra OBJECT
         MiddleSizeVector.cpp
-        MiddleSizeMatrix.cpp)
+        MiddleSizeMatrix.cpp
+        SmallVector.cpp)
 target_link_libraries(LinearAlgebra
     PUBLIC
         Logger

--- a/kernel/LinearAlgebra/MiddleSizeVector.h
+++ b/kernel/LinearAlgebra/MiddleSizeVector.h
@@ -44,10 +44,11 @@
 #include <cmath>
 #include <iostream>
 #include <complex>
+
+#include "Types.h"
+
 namespace hpgem {
 namespace LinearAlgebra {
-template <std::size_t numberOfRows>
-class SmallVector;
 
 /// \class MiddleSizeVector
 /// \brief This is a vector of doubles
@@ -79,8 +80,8 @@ class MiddleSizeVector {
     MiddleSizeVector(MiddleSizeVector&& other);
 
     // implemented with SmallVector for dependency reasons
-    template <std::size_t numberOfRows>
-    MiddleSizeVector(const SmallVector<numberOfRows>& other);
+    template <std::size_t numberOfRows, typename EntryT>
+    MiddleSizeVector(const GSmallVector<numberOfRows, EntryT>& other);
 
     MiddleSizeVector(const type array[], std::size_t size);
 

--- a/kernel/LinearAlgebra/SmallVector.cpp
+++ b/kernel/LinearAlgebra/SmallVector.cpp
@@ -7,7 +7,7 @@
  below.
 
 
- Copyright (c) 2014, University of Twente
+ Copyright (c) 2021, University of Twente
  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
@@ -36,50 +36,23 @@
  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef HPGEM_KERNEL_PHYSGRADIENTOFBASISFUNCTION_H
-#define HPGEM_KERNEL_PHYSGRADIENTOFBASISFUNCTION_H
+#include "SmallVector.h"
 
-#include "Logger.h"
 namespace hpgem {
+namespace LinearAlgebra {
 
-namespace Geometry {
-template <std::size_t DIM>
-class PointReference;
+
+template class GSmallVector<0, double>;
+template class GSmallVector<1, double>;
+template class GSmallVector<2, double>;
+template class GSmallVector<3, double>;
+template class GSmallVector<4, double>;
+
+template class GSmallVector<0, std::complex<double>>;
+template class GSmallVector<1, std::complex<double>>;
+template class GSmallVector<2, std::complex<double>>;
+template class GSmallVector<3, std::complex<double>>;
+template class GSmallVector<4, std::complex<double>>;
+
 }
-
-namespace Base {
-class Element;
-class BaseBasisFunction;
-}  // namespace Base
-
-namespace Utilities {
-/*! For a basis function we also need its physical space gradient as opposed
- *  to the one in reference space (which can be harvested by evaluating the
- *  derivatives of basis functions). Hence this class computes the
- *  reference space gradient, transforms it with the Jacobian of the mapping
- *  and thus yields the physical space gradient.
- *  \deprecated functionality is specific for H1 conforming basisfunctions*/
-struct PhysGradientOfBasisFunction {
-
-    PhysGradientOfBasisFunction(const Base::Element* e,
-                                const Base::BaseBasisFunction* function)
-        : myElement_(e), myFunction_(function) {
-        logger.assert_debug(e != nullptr, "Invalid element passed");
-        logger.assert_debug(function != nullptr, "Invalid function passed");
-    }
-
-    //! Evaluation operator, also compatible with integration routines.
-    template <std::size_t DIM>
-    LinearAlgebra::SmallVector<DIM> operator()(
-        const Geometry::PointReference<DIM>& p) const;
-
-   private:
-    const Base::Element* myElement_;
-    const Base::BaseBasisFunction* myFunction_;
-};
-
-}  // namespace Utilities
-}  // namespace hpgem
-#include "PhysGradientOfBasisFunction_Impl.h"
-
-#endif  // HPGEM_KERNEL_PHYSGRADIENTOFBASISFUNCTION_H
+}

--- a/kernel/LinearAlgebra/SmallVector.cpp
+++ b/kernel/LinearAlgebra/SmallVector.cpp
@@ -41,7 +41,6 @@
 namespace hpgem {
 namespace LinearAlgebra {
 
-
 template class GSmallVector<0, double>;
 template class GSmallVector<1, double>;
 template class GSmallVector<2, double>;
@@ -54,5 +53,5 @@ template class GSmallVector<2, std::complex<double>>;
 template class GSmallVector<3, std::complex<double>>;
 template class GSmallVector<4, std::complex<double>>;
 
-}
-}
+}  // namespace LinearAlgebra
+}  // namespace hpgem

--- a/kernel/LinearAlgebra/SmallVector.h
+++ b/kernel/LinearAlgebra/SmallVector.h
@@ -94,8 +94,13 @@ inline std::complex<double> conj(std::complex<double> v) {
 
 inline std::size_t hash(double v) noexcept { return std::hash<double>()(v); }
 inline std::size_t hash(std::complex<double> v) noexcept {
+    // Same as
+    // https://stackoverflow.com/questions/1646807/quick-and-simple-hash-code-combinations
+    std::size_t hash = 17;
+    hash = hash * 31 + std::hash<double>()(v.real());
+    hash = hash * 31 + std::hash<double>()(v.imag());
 
-    return std::hash<double>()(v.real()) + 17 * std::hash<double>()(v.imag());
+    return hash;
 }
 
 inline bool less(const double& v1, const double& v2) noexcept {
@@ -379,13 +384,16 @@ class GSmallVector {
     }
 
     std::size_t hash() const noexcept {
-        std::size_t result = 0;
+        // Similar to
+        // https://stackoverflow.com/questions/1646807/quick-and-simple-hash-code-combinations
+
+        std::size_t hash = 17;
         for (std::size_t i = 0; i < numberOfRows; ++i) {
             // Basic hash combining function
             std::size_t v = Detail::hash(data_[i]);
-            result ^= v + 0x9e3779b9L + (result << 6) + (result >> 2);
+            hash = hash * 31 + v;
         }
-        return result;
+        return hash;
     }
 
     SmallVector<numberOfRows> real() const {

--- a/kernel/LinearAlgebra/SmallVector.h
+++ b/kernel/LinearAlgebra/SmallVector.h
@@ -388,6 +388,22 @@ class GSmallVector {
         return result;
     }
 
+    SmallVector<numberOfRows> real() const {
+        SmallVector<numberOfRows> res;
+        for (std::size_t i = 0; i < numberOfRows; ++i) {
+            res[i] = std::real(data_[i]);
+        }
+        return res;
+    }
+
+    SmallVector<numberOfRows> imag() const {
+        SmallVector<numberOfRows> res;
+        for (std::size_t i = 0; i < numberOfRows; ++i) {
+            res[i] = std::imag(data_[i]);
+        }
+        return res;
+    }
+
    private:
     std::array<EntryT, numberOfRows> data_;
 };

--- a/kernel/LinearAlgebra/SmallVector.h
+++ b/kernel/LinearAlgebra/SmallVector.h
@@ -36,55 +36,105 @@
  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef HPGEM_KERNEL_SMALLVECTOR_H
-#define HPGEM_KERNEL_SMALLVECTOR_H
+#ifndef HPGEM_KERNEL_GSmallVector_H
+#define HPGEM_KERNEL_GSmallVector_H
+
+// Note: there is an depenency between MiddleSizeVector and SmallVector to allow
+// conversion.
+#include "MiddleSizeVector.h"
 
 #include "Logger.h"
+#include <algorithm>
 #include <array>
 #include <cmath>
-#include "MiddleSizeVector.h"
-#include <algorithm>
+#include <functional>
 #include <numeric>
 
 namespace hpgem {
 namespace LinearAlgebra {
-class MiddleSizeVector;
-/// \class SmallVector
-/// \brief This is a vector of doubles
+
+namespace Detail {
+// Several helper functions for GSmallVector.
+//   - CrossProduct requires partial specialization
+//
+template <typename T>
+void computeCrossProduct(const GSmallVector<2, T>&, const GSmallVector<2, T>&,
+                         GSmallVector<2, T>&);
+template <typename T>
+void computeCrossProduct(const GSmallVector<3, T>&, const GSmallVector<3, T>&,
+                         GSmallVector<3, T>&);
+template <typename std::size_t nRows, typename T>
+void computeCrossProduct(const GSmallVector<nRows, T>&,
+                         const GSmallVector<nRows, T>&,
+                         GSmallVector<nRows, T>&);
+
+inline MiddleSizeVector::type convertToMiddleSize(std::complex<double> v);
+inline MiddleSizeVector::type convertToMiddleSize(double v);
+// As out argument to allow overloading
+inline void convertFromMiddleSize(MiddleSizeVector::type v, double& out);
+inline void convertFromMiddleSize(MiddleSizeVector::type v,
+                                  std::complex<double>& out);
+
+inline double conj(double v) { return v; }
+inline std::complex<double> conj(std::complex<double> v) {
+    return std::conj(v);
+}
+
+inline std::size_t hash(double v) noexcept { return std::hash<double>()(v); }
+inline std::size_t hash(std::complex<double> v) noexcept {
+
+    return std::hash<double>()(v.real()) + 17 * std::hash<double>()(v.imag());
+}
+
+inline bool less(const double& v1, const double& v2) noexcept {
+    return v1 < v2;
+}
+inline bool less(const std::complex<double>& v1,
+                 const std::complex<double>& v2) noexcept {
+    if (v1.real() != v2.real()) {
+        return v1.real() < v2.real();
+    } else {
+        return v1.imag() < v2.imag();
+    }
+}
+
+}  // namespace Detail
+
+// Note specialization to SmallVector/SmallVectorC in Types.h
+
+/// \class GSmallVector
+/// \brief This is a fixed size vector of generic type (supported: double,
+/// std::complex<double>)
 ///
-/// \details
-/// This implements a vector of doubles and all the standard operators for it.
-/// Note it is encapulating a std::array for its data storage.
-template <std::size_t numberOfRows>
-class SmallVector {
+/// \tparam numberOfRows The number of rows or columns in this vector
+/// \tparam EntryT The value type
+template <std::size_t numberOfRows, typename EntryT>
+class GSmallVector {
 
    public:
-    SmallVector() : data_() {}
+    GSmallVector() : data_() {}
 
-    /*SmallVector(std::array<double, numberOfRows> t)
+    /*GSmallVector(std::array<double, numberOfRows> t)
         : data_(t)
     {
     }*/
 
-    SmallVector(const SmallVector& other) : data_(other.data_) {}
+    GSmallVector(const GSmallVector& other) : data_(other.data_) {}
 
     // this constructor is implicit because both vector types should allow for
     // the same mathematical operations, with the only potential difference
     // being in the implementation
-    SmallVector(const MiddleSizeVector& other) : data_() {
+    GSmallVector(const MiddleSizeVector& other) : data_() {
         logger.assert_debug(
             other.size() == numberOfRows,
             "Cannot construct a vector of size % from a vector of size %",
             numberOfRows, other.size());
         for (std::size_t i = 0; i < numberOfRows; ++i) {
-            logger.assert_debug(std::abs(other[i] - std::real(other[i])) < 1e-9,
-                                "trying to construct a real vector from a "
-                                "vector with nonzero complex component");
-            data_[i] = std::real(other[i]);
+            Detail::convertFromMiddleSize(other[i], data_[i]);
         }
     }
 
-    SmallVector(const std::vector<double>& vec) {
+    GSmallVector(const std::vector<EntryT>& vec) {
         logger.assert_debug(
             vec.size() == numberOfRows,
             "Cannot construct a vector of size % from a std::vector of size %",
@@ -92,73 +142,76 @@ class SmallVector {
         std::copy_n(vec.begin(), numberOfRows, data_.begin());
     }
 
-    SmallVector(SmallVector&& other) : data_(std::move(other.data_)) {}
+    GSmallVector(GSmallVector&& other) : data_(std::move(other.data_)) {}
 
-    SmallVector(const double array[]) : data_() {
+    GSmallVector(const EntryT array[]) : data_() {
         std::copy(array, array + numberOfRows, data_.begin());
     }
 
-    SmallVector(std::initializer_list<double> data) : data_() {
+    GSmallVector(std::initializer_list<EntryT> data) : data_() {
         logger.assert_debug(data.size() == numberOfRows,
                             "provided array has size %, but should have size %",
                             data.size(), numberOfRows);
         std::copy(data.begin(), data.end(), data_.begin());
     }
 
-    SmallVector& operator=(const SmallVector& right) {
+    GSmallVector& operator=(const GSmallVector& right) {
         std::copy(right.data_.begin(), right.data_.end(), data_.begin());
         return *this;
     }
 
-    SmallVector& operator=(const std::array<double, numberOfRows> l) {
+    GSmallVector& operator=(const std::array<EntryT, numberOfRows> l) {
         std::copy(l.begin(), l.end(), data_.begin());
         return *this;
     }
 
-    SmallVector operator+(const SmallVector& right) const {
-        SmallVector result;
+    GSmallVector operator+(const GSmallVector& right) const {
+        GSmallVector result;
         std::transform(data_.begin(), data_.end(), right.data_.begin(),
-                       result.data_.begin(), std::plus<double>());
+                       result.data_.begin(), std::plus<EntryT>());
         return result;
     }
 
-    SmallVector operator-(const SmallVector& right) const {
-        SmallVector result;
+    GSmallVector operator-(const GSmallVector& right) const {
+        GSmallVector result;
         std::transform(data_.begin(), data_.end(), right.data_.begin(),
-                       result.data_.begin(), std::minus<double>());
+                       result.data_.begin(), std::minus<EntryT>());
         return result;
     }
 
-    SmallVector operator*(const double& right) const {
-        SmallVector result;
+    GSmallVector operator*(const EntryT& right) const {
+        GSmallVector result;
         std::transform(
             data_.begin(), data_.end(), result.data_.begin(),
-            std::bind(std::multiplies<double>(), std::placeholders::_1, right));
+            std::bind(std::multiplies<EntryT>(), std::placeholders::_1, right));
         return result;
     }
 
     /// Computes inner product between two vectors.
-    double operator*(const SmallVector& right) const {
-        return std::inner_product(right.data_.begin(), right.data_.end(),
-                                  data_.begin(), 0.);
-    }
-
-    SmallVector& operator/=(const double& right) {
-        std::transform(
-            data_.begin(), data_.end(), data_.begin(),
-            std::bind(std::divides<double>(), std::placeholders::_1, right));
-        return *this;
-    }
-
-    SmallVector operator/(const double& right) const {
-        SmallVector result;
-        std::transform(
-            data_.begin(), data_.end(), result.data_.begin(),
-            std::bind(std::divides<double>(), std::placeholders::_1, right));
+    EntryT operator*(const GSmallVector& right) const {
+        EntryT result = 0;
+        for (std::size_t i = 0; i < numberOfRows; ++i) {
+            result += data_[i] * Detail::conj(right.data_[i]);
+        }
         return result;
     }
 
-    void axpy(double a, const SmallVector& x) {
+    GSmallVector& operator/=(const EntryT& right) {
+        std::transform(
+            data_.begin(), data_.end(), data_.begin(),
+            std::bind(std::divides<EntryT>(), std::placeholders::_1, right));
+        return *this;
+    }
+
+    GSmallVector operator/(const EntryT& right) const {
+        GSmallVector result;
+        std::transform(
+            data_.begin(), data_.end(), result.data_.begin(),
+            std::bind(std::divides<EntryT>(), std::placeholders::_1, right));
+        return result;
+    }
+
+    void axpy(EntryT a, const GSmallVector& x) {
         for (std::size_t i = 0; i < numberOfRows; ++i) {
             data_[i] += a * x[i];
         }
@@ -166,7 +219,7 @@ class SmallVector {
 
     /// This function is dangerous to use, since it compares doubles without
     /// a tolerance interval to see if they are equal.
-    bool operator==(const SmallVector& right) const {
+    bool operator==(const GSmallVector& right) const {
         for (std::size_t i = 0; i < numberOfRows; ++i) {
             if (data_[i] != right[i]) {
                 return false;
@@ -175,61 +228,59 @@ class SmallVector {
         return true;
     }
 
-    /// This function is dangerous to use, since it compares doubles without
-    /// a tolerance interval to see if they are equal.
-    bool operator<(const SmallVector& right) const {
+    /// Lexicographic ordering of vectors, note that it does not use any
+    /// tolerances.
+    bool operator<(const GSmallVector& right) const {
         for (std::size_t i = 0; i < numberOfRows; ++i) {
-            if (data_[i] < right[i]) {
-                return true;
-            }
-            if (data_[i] > right[i]) {
-                return false;
+            if (data_[i] != right.data_[i]) {
+                return Detail::less(data_[i], right.data_[i]);
             }
         }
+        // Equals
         return false;
     }
 
-    SmallVector& operator+=(const SmallVector& right) {
+    GSmallVector& operator+=(const GSmallVector& right) {
         std::transform(data_.begin(), data_.end(), right.data_.begin(),
-                       data_.begin(), std::plus<double>());
+                       data_.begin(), std::plus<EntryT>());
         return *this;
     }
 
-    SmallVector& operator-=(const SmallVector& right) {
+    GSmallVector& operator-=(const GSmallVector& right) {
         std::transform(data_.begin(), data_.end(), right.data_.begin(),
-                       data_.begin(), std::minus<double>());
+                       data_.begin(), std::minus<EntryT>());
         return *this;
     }
 
-    SmallVector& operator*=(const double& right) {
+    GSmallVector& operator*=(const EntryT& right) {
         std::transform(
             data_.begin(), data_.end(), data_.begin(),
-            std::bind(std::multiplies<double>(), std::placeholders::_1, right));
+            std::bind(std::multiplies<EntryT>(), std::placeholders::_1, right));
         return *this;
     }
 
-    double& operator[](std::size_t n) {
+    EntryT& operator[](std::size_t n) {
         logger.assert_debug(n < numberOfRows,
                             "Requested entry %, but there are only % entries",
                             n, numberOfRows);
         return data_[n];
     }
 
-    const double& operator[](std::size_t n) const {
+    const EntryT& operator[](std::size_t n) const {
         logger.assert_debug(n < numberOfRows,
                             "Requested entry %, but there are only % entries",
                             n, numberOfRows);
         return data_[n];
     }
 
-    double& operator()(std::size_t n) {
+    EntryT& operator()(std::size_t n) {
         logger.assert_debug(n < numberOfRows,
                             "Requested entry %, but there are only % entries",
                             n, numberOfRows);
         return data_[n];
     }
 
-    const double& operator()(std::size_t n) const {
+    const EntryT& operator()(std::size_t n) const {
         logger.assert_debug(n < numberOfRows,
                             "Requested entry %, but there are only % entries",
                             n, numberOfRows);
@@ -237,13 +288,13 @@ class SmallVector {
     }
 
     std::size_t size() const { return numberOfRows; }
-    const double* data() const { return data_.data(); }
+    const EntryT* data() const { return data_.data(); }
 
-    double* data() { return data_.data(); }
+    EntryT* data() { return data_.data(); }
 
-    SmallVector operator-() const { return *this * -1.; }
+    GSmallVector operator-() const { return *this * -1.; }
 
-    void set(double value) {
+    void set(EntryT value) {
         for (std::size_t i = 0; i < numberOfRows; ++i) {
             data_[i] = value;
         }
@@ -258,15 +309,40 @@ class SmallVector {
     /// component of the vector with the second one zero.
     /// \param other The second argument of the cross product.
     /// \param result A vector to store the result in.
-    void crossProduct(const SmallVector& other, SmallVector& result) const;
+    void crossProduct(const GSmallVector<numberOfRows, EntryT>& other,
+                      GSmallVector<numberOfRows, EntryT>& result) const {
+        Detail::computeCrossProduct(*this, other, result);
+    }
 
-    SmallVector crossProduct(const SmallVector& other) const {
-        SmallVector result;
+    GSmallVector crossProduct(
+        const GSmallVector<numberOfRows, EntryT>& other) const {
+        GSmallVector result;
         crossProduct(other, result);
         return result;
     }
 
-    double l2NormSquared() const { return this->operator*(*this); }
+    // For implementation of the cross product without having to specialize
+    // for N=2 and N=3
+    template <typename T>
+    friend void Detail::computeCrossProduct(const GSmallVector<2, T>&,
+                                            const GSmallVector<2, T>&,
+                                            GSmallVector<2, T>&);
+    template <typename T>
+    friend void Detail::computeCrossProduct(const GSmallVector<3, T>&,
+                                            const GSmallVector<3, T>&,
+                                            GSmallVector<3, T>&);
+    template <std::size_t n, typename T>
+    friend void Detail::computeCrossProduct(const GSmallVector<n, T>&,
+                                            const GSmallVector<n, T>&,
+                                            GSmallVector<n, T>&);
+
+    double l2NormSquared() const {
+        double result = 0.0;
+        for (std::size_t i = 0; i < numberOfRows; ++i) {
+            result += std::norm(data_[i]);
+        }
+        return result;
+    }
 
     double l2Norm() const { return std::sqrt(l2NormSquared()); }
 
@@ -275,25 +351,36 @@ class SmallVector {
     /// \param value The value to append
     /// \return A new vector with the value appended to the values in this
     /// vector.
-    SmallVector<numberOfRows + 1> append(double value) {
-        SmallVector<numberOfRows + 1> result;
+    GSmallVector<numberOfRows + 1, EntryT> append(EntryT value) {
+        GSmallVector<numberOfRows + 1, EntryT> result;
         for (std::size_t i = 0; i < numberOfRows; ++i) result[i] = data_[i];
         result[numberOfRows] = value;
         return result;
     }
 
+    std::size_t hash() const noexcept {
+        std::size_t result = 0;
+        for (std::size_t i = 0; i < numberOfRows; ++i) {
+            // Basic hash combining function
+            std::size_t v = Detail::hash(data_[i]);
+            result ^= v + 0x9e3779b9L + (result << 6) + (result >> 2);
+        }
+        return result;
+    }
+
    private:
-    std::array<double, numberOfRows> data_;
+    std::array<EntryT, numberOfRows> data_;
 };
 
-template <std::size_t numberOfRows>
-SmallVector<numberOfRows> operator*(const double& left,
-                                    const SmallVector<numberOfRows>& right) {
+template <std::size_t numberOfRows, typename EntryT>
+GSmallVector<numberOfRows, EntryT> operator*(
+    const EntryT& left, const GSmallVector<numberOfRows, EntryT>& right) {
     return right * left;
 }
 
-template <std::size_t numberOfRows>
-std::ostream& operator<<(std::ostream& os, const SmallVector<numberOfRows>& A) {
+template <std::size_t numberOfRows, typename EntryT>
+std::ostream& operator<<(std::ostream& os,
+                         const GSmallVector<numberOfRows, EntryT>& A) {
     os << "(";
     for (std::size_t i = 0; i < numberOfRows; ++i) {
         os << A[i] << " ";
@@ -302,59 +389,114 @@ std::ostream& operator<<(std::ostream& os, const SmallVector<numberOfRows>& A) {
     return os;
 }
 
-template <>
-inline void SmallVector<2>::crossProduct(
-    const LinearAlgebra::SmallVector<2>& other,
-    LinearAlgebra::SmallVector<2>& result) const {
-    result[0] = data_[0] * other[1] - data_[1] * other[0];
-    result[1] = 0;
-}
+namespace Detail {
 
-template <>
-inline void SmallVector<3>::crossProduct(
-    const LinearAlgebra::SmallVector<3>& other,
-    LinearAlgebra::SmallVector<3>& result) const {
-    result[0] = data_[1] * other[2] - data_[2] * other[1];
-    result[1] = data_[2] * other[0] - data_[0] * other[2];
-    result[2] = data_[0] * other[1] - data_[1] * other[0];
+template <typename T>
+void computeCrossProduct(const GSmallVector<2, T>& v1,
+                         const GSmallVector<2, T>& v2,
+                         GSmallVector<2, T>& result) {
+    result[0] = v1.data_[0] * v2.data_[1] - v1.data_[1] * v2.data_[0];
+    result[1] = 0.0;
 }
-
-template <std::size_t numberOfRows>
-inline void SmallVector<numberOfRows>::crossProduct(
-    const LinearAlgebra::SmallVector<numberOfRows>& other,
-    LinearAlgebra::SmallVector<numberOfRows>& result) const {
+template <typename T>
+void computeCrossProduct(const GSmallVector<3, T>& v1,
+                         const GSmallVector<3, T>& v2,
+                         GSmallVector<3, T>& result) {
+    result[0] = v1.data_[1] * v2.data_[2] - v1.data_[2] * v2.data_[1];
+    result[1] = v1.data_[2] * v2.data_[0] - v1.data_[0] * v2.data_[2];
+    result[2] = v1.data_[0] * v2.data_[1] - v1.data_[1] * v2.data_[0];
+}
+template <typename std::size_t nRows, typename T>
+void computeCrossProduct(const GSmallVector<nRows, T>&,
+                         const GSmallVector<nRows, T>&,
+                         GSmallVector<nRows, T>&) {
     logger.assert_debug(
         false, "Cross product only defined for 2 and 3D vectors, not for % ",
-        numberOfRows);
+        nRows);
 }
 
-#ifdef HPGEM_USE_COMPLEX_PETSC
-template <std::size_t nRows>
-MiddleSizeVector::MiddleSizeVector(const SmallVector<nRows>& other)
+}  // namespace Detail
+
+template <std::size_t nRows, typename EntryT>
+MiddleSizeVector::MiddleSizeVector(const GSmallVector<nRows, EntryT>& other)
     : data_(nRows) {
     logger(WARN,
            "Constructing middle size vector from small vector, consider using "
            "small vectors everywhere for fixed length vectors of size <= 4");
     for (std::size_t i = 0; i < nRows; ++i) {
-        logger.assert_debug(std::abs(other[i] - std::real(other[i])) < 1e-9,
-                            "attempting to construct a real vector from a "
-                            "vector with a complex part");
-        data_[i] = std::real(other[i]);
+        data_[i] = Detail::convertToMiddleSize(other[i]);
     }
 }
+
+namespace Detail {
+#ifdef HPGEM_USE_COMPLEX_PETSC
+
+inline MiddleSizeVector::type convertToMiddleSize(double v) { return v; }
+inline MiddleSizeVector::type convertToMiddleSize(std::complex<double> v) {
+    return v;
+}
+
+// Conversion to a real valued small vector will be a problem
+inline void convertFromMiddleSize(MiddleSizeVector::type v, double& out) {
+    logger.assert_debug(std::abs(v.imag()) < 1e-9,
+                        "Constructing a real SmallVector from a complex valued "
+                        "MiddleSizeVector");
+    out = v.real();
+}
+inline void convertFromMiddleSize(MiddleSizeVector::type v,
+                                  std::complex<double>& out) {
+    out = v;
+}
+
 #else
-template <std::size_t numberOfRows>
-MiddleSizeVector::MiddleSizeVector(const SmallVector<numberOfRows>& other)
-    : data_(other.data(), other.data() + numberOfRows) {
-    logger(
-        WARN,
-        "Constructing middle size vector from small vector, consider "
-        "using small vectors everywhere for fixed length vectors of size <= 4. "
-        "This warning might also be caused because of an operation between a "
-        "small vector and a middle size vector.");
+
+inline MiddleSizeVector::type convertToMiddleSize(std::complex<double> v) {
+    logger.assert_debug(std::abs(v.imag()) < 1e-9,
+                        "Converting a complex valued SmallVector to a real "
+                        "valued MiddleSizeVector");
+    return v.real();
+}
+
+inline MiddleSizeVector::type convertToMiddleSize(double v) { return v; }
+
+// Both pass through
+inline void convertFromMiddleSize(MiddleSizeVector::type v, double& out) {
+    out = v;
+}
+inline void convertFromMiddleSize(MiddleSizeVector::type v,
+                                  std::complex<double>& out) {
+    out = v;
 }
 #endif
+}  // namespace Detail
+
+// Standard instances
+extern template class GSmallVector<0, double>;
+extern template class GSmallVector<1, double>;
+extern template class GSmallVector<2, double>;
+extern template class GSmallVector<3, double>;
+extern template class GSmallVector<4, double>;
+
+extern template class GSmallVector<0, std::complex<double>>;
+extern template class GSmallVector<1, std::complex<double>>;
+extern template class GSmallVector<2, std::complex<double>>;
+extern template class GSmallVector<3, std::complex<double>>;
+extern template class GSmallVector<4, std::complex<double>>;
 
 }  // namespace LinearAlgebra
 }  // namespace hpgem
-#endif  // HPGEM_KERNEL_SMALLVECTOR_H
+
+namespace std {
+
+template <std::size_t numberOfRows>
+struct hash<hpgem::LinearAlgebra::GSmallVector<numberOfRows, double>> {
+    std::size_t operator()(
+        const hpgem::LinearAlgebra::GSmallVector<numberOfRows, double>& v)
+        const noexcept {
+        return v.hash();
+    }
+};
+
+}  // namespace std
+
+#endif  // HPGEM_KERNEL_GSmallVector_H

--- a/kernel/LinearAlgebra/Types.h
+++ b/kernel/LinearAlgebra/Types.h
@@ -43,18 +43,18 @@
 // Predeclaration header for LinearAlgebra
 
 namespace hpgem {
-namespace LinearAlgebra{
+namespace LinearAlgebra {
 
-template<std::size_t numberOfRows, typename EntryT>
+template <std::size_t numberOfRows, typename EntryT>
 class GSmallVector;
-template<std::size_t numberOfRows>
+template <std::size_t numberOfRows>
 using SmallVector = GSmallVector<numberOfRows, double>;
-template<std::size_t numberOfRows>
+template <std::size_t numberOfRows>
 using SmallVectorC = GSmallVector<numberOfRows, std::complex<double>>;
 
 class MiddleSizeVector;
 
-}
-}
+}  // namespace LinearAlgebra
+}  // namespace hpgem
 
 #endif  // HPGEM_TYPES_H

--- a/kernel/LinearAlgebra/Types.h
+++ b/kernel/LinearAlgebra/Types.h
@@ -7,7 +7,7 @@
  below.
 
 
- Copyright (c) 2014, University of Twente
+ Copyright (c) 2021, University of Twente
  All rights reserved.
 
  Redistribution and use in source and binary forms, with or without
@@ -35,51 +35,26 @@
  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+#ifndef HPGEM_TYPES_H
+#define HPGEM_TYPES_H
 
-#ifndef HPGEM_KERNEL_PHYSGRADIENTOFBASISFUNCTION_H
-#define HPGEM_KERNEL_PHYSGRADIENTOFBASISFUNCTION_H
+#include <memory>
 
-#include "Logger.h"
+// Predeclaration header for LinearAlgebra
+
 namespace hpgem {
+namespace LinearAlgebra{
 
-namespace Geometry {
-template <std::size_t DIM>
-class PointReference;
+template<std::size_t numberOfRows, typename EntryT>
+class GSmallVector;
+template<std::size_t numberOfRows>
+using SmallVector = GSmallVector<numberOfRows, double>;
+template<std::size_t numberOfRows>
+using SmallVectorC = GSmallVector<numberOfRows, std::complex<double>>;
+
+class MiddleSizeVector;
+
+}
 }
 
-namespace Base {
-class Element;
-class BaseBasisFunction;
-}  // namespace Base
-
-namespace Utilities {
-/*! For a basis function we also need its physical space gradient as opposed
- *  to the one in reference space (which can be harvested by evaluating the
- *  derivatives of basis functions). Hence this class computes the
- *  reference space gradient, transforms it with the Jacobian of the mapping
- *  and thus yields the physical space gradient.
- *  \deprecated functionality is specific for H1 conforming basisfunctions*/
-struct PhysGradientOfBasisFunction {
-
-    PhysGradientOfBasisFunction(const Base::Element* e,
-                                const Base::BaseBasisFunction* function)
-        : myElement_(e), myFunction_(function) {
-        logger.assert_debug(e != nullptr, "Invalid element passed");
-        logger.assert_debug(function != nullptr, "Invalid function passed");
-    }
-
-    //! Evaluation operator, also compatible with integration routines.
-    template <std::size_t DIM>
-    LinearAlgebra::SmallVector<DIM> operator()(
-        const Geometry::PointReference<DIM>& p) const;
-
-   private:
-    const Base::Element* myElement_;
-    const Base::BaseBasisFunction* myFunction_;
-};
-
-}  // namespace Utilities
-}  // namespace hpgem
-#include "PhysGradientOfBasisFunction_Impl.h"
-
-#endif  // HPGEM_KERNEL_PHYSGRADIENTOFBASISFUNCTION_H
+#endif  // HPGEM_TYPES_H

--- a/tests/unit/LinearAlgebra/SmallVectorUnitTest.cpp
+++ b/tests/unit/LinearAlgebra/SmallVectorUnitTest.cpp
@@ -310,3 +310,21 @@ TEST_CASE("Conversion complex <-> real", "[SmallVectorUnitTest]") {
     INFO("Conversion complex -> real");
     CHECK(SmallVector<1>(vcreal) == vreal);
 }
+
+TEST_CASE("Vector real imag", "[SmallVectorUnitTest]") {
+    SmallVectorC<2> cvector = {1.0 + 2.0i, 3.0 + 4.0i};
+    SmallVector<2> realPart = {1.0, 3.0};
+    SmallVector<2> imagPart = {2.0, 4.0};
+    SmallVector<2> zeroVec = {0.0, 0.0};
+
+    {
+        INFO("Check complex vector")
+        CHECK(cvector.real() == realPart);
+        CHECK(cvector.imag() == imagPart);
+    }
+    {
+        INFO("Check real vector");
+        CHECK(realPart.real() == realPart);
+        CHECK(realPart.imag() == zeroVec);
+    }
+}

--- a/tests/unit/LinearAlgebra/SmallVectorUnitTest.cpp
+++ b/tests/unit/LinearAlgebra/SmallVectorUnitTest.cpp
@@ -47,8 +47,10 @@
 
 using namespace hpgem;
 using LinearAlgebra::SmallVector;
+using LinearAlgebra::SmallVectorC;
+using namespace std::complex_literals;
 
-void crossProductTests3D() {
+TEST_CASE("Cross product 3D", "[SmallVectorUnitTest]") {
     SmallVector<3> x({1, 0, 0}), y({0, 1, 0}), z({0, 0, 1});
 
     // Checking the orientation.
@@ -91,7 +93,8 @@ void crossProductTests3D() {
           1e-12);
 }
 
-void crossProductTests2D() {
+// Run 3D case first, as this uses that
+TEST_CASE("Cross product 2D", "[SmallVectorUnitTest]") {
     SmallVector<2> x({1, 0}), y({0, 1});
 
     // Checking basic unit vectors crosses
@@ -271,9 +274,28 @@ TEST_CASE("SmallVectorUnitTest", "[SmallVectorUnitTest]") {
     CHECK(std::abs(convenient(3) - 2.) < 1e-12);
 
     std::cout << pc2 << convenient << std::endl;
+}
 
-    crossProductTests3D();
-    // Test 2D after 3D as it test the equivalence between 2D cross product and
-    // 3D crossproduct
-    crossProductTests2D();
+TEST_CASE("L2Norm", "[SmallVectorUnitTest]") {
+    // Following tests use integers and should therefore be exact.
+    SmallVector<2> v1 = {2.0, 3.0};
+    CHECK(v1.l2NormSquared() == 13);
+    SmallVectorC<2> vc1 = {2.0 + 3.0i, 4.0 + 5.0i};
+    CHECK(vc1.l2NormSquared() == 4 + 9 + 16 + 25);
+}
+
+TEST_CASE("Complex Inner product", "[SmallVectorUnitTest]") {
+    SmallVectorC<2> v1 = {1.0 + 2.0i, 1.0};
+    SmallVectorC<2> v2 = {1.0i, 3.0 + 2.0i};
+    // Expected value: 5-3i
+    // (1+2i) * conj(1i) = 2-1i
+    // 1 * conj(3+2i)    = 3-2i
+    CHECK(v1 * v2 == 5.0 - 3.0i);
+    // Flipping the order conjugates the output
+    CHECK(v2 * v1 == 5.0 + 3.0i);
+
+    // Consistency with l2 norm squared
+    INFO("l2 norm <-> inner product equivalence");
+    CHECK(v1 * v1 == 1.0 + 4.0 + 1.0);
+    CHECK(v2 * v2 == 1.0 + 4.0 + 9.0);
 }

--- a/tests/unit/LinearAlgebra/SmallVectorUnitTest.cpp
+++ b/tests/unit/LinearAlgebra/SmallVectorUnitTest.cpp
@@ -299,3 +299,14 @@ TEST_CASE("Complex Inner product", "[SmallVectorUnitTest]") {
     CHECK(v1 * v1 == 1.0 + 4.0 + 1.0);
     CHECK(v2 * v2 == 1.0 + 4.0 + 9.0);
 }
+
+TEST_CASE("Conversion complex <-> real", "[SmallVectorUnitTest]") {
+    SmallVector<1> vreal = {1.0};
+    SmallVectorC<1> vcreal = {1.0 + 0i};
+
+    INFO("Conversion real -> complex");
+    CHECK(SmallVectorC<1>(vreal) == vcreal);
+
+    INFO("Conversion complex -> real");
+    CHECK(SmallVector<1>(vcreal) == vreal);
+}


### PR DESCRIPTION
Introduces the option to have complex valued vectors of fixed size (`SmallVectorC`).

This is quite a bit more messy than expected due to several complicating factors:
 1. There are several differences between `double` and `complex<double>` in the standard library, like '<' working only on doubles, and `std::conj` always returning a `complex<double>`.
 2. The specialization of CrossProduct for vectors of size 2 and 3 now becomes a partial specialization
 3. The MiddleSizeVector (and matrix for that matter), can be real or complex valued depending on what petsc uses, which makes conversion SmallVector <-> MiddleSizeVector complicated. Removing this ambiguity from MiddleSizeVector is very time intensive, as it is intertwined with the Mesh.

This PR tries to balance time investment against doing "the right thing". In the end it would probably be better to replace all the linear algebra by an external library, but that would require a major investment of time.