### PR TITLE
Add option to control MPI log output in DGMax

### DIFF
--- a/applications/DG-Max/DGMaxLogger.cpp
+++ b/applications/DG-Max/DGMaxLogger.cpp
@@ -1,7 +1,45 @@
+/*
+ This file forms part of hpGEM. This package has been developed over a number of
+ years by various people at the University of Twente and a full list of
+ contributors can be found at http://hpgem.org/about-the-code/team
 
+ This code is distributed using BSD 3-Clause License. A copy of which can found
+ below.
+
+
+ Copyright (c) 2018, University of Twente
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation
+ and/or other materials provided with the distribution.
+
+ 3. Neither the name of the copyright holder nor the names of its contributors
+ may be used to endorse or promote products derived from this software without
+ specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 #include "DGMaxLogger.h"
+#include "Base/CommandLineOptions.h"
 #include <iostream>
 #include <iomanip>
+#include <algorithm>
 
 #ifdef HPGEM_USE_MPI
 #include <mpi.h>
@@ -43,7 +81,39 @@ void logAll(std::function<void()> log) {
 
 bool loggingSuppressed() { return commRank != 0 && !logAllEnabled; }
 
-void initDGMaxLogging() {
+static Base::CommandLineOption<std::string>* restrictionOption = nullptr;
+
+void registerLogLevelCommandLineFlag() {
+    restrictionOption = &Base::register_argument<std::string>(
+        '\0', "mpiloglevel",
+        "Level from which to log messages from all MPI processes, possible "
+        "values error, warn, info, verbose, debug",
+        false, "");
+}
+
+namespace {
+
+using LogFunction = std::function<void(std::string, std::string)>;
+
+/**
+ * Select the function to log a message based on the restriction level.
+ *
+ * @param level Level of the messages to log
+ * @param restriction Level below which not to log from all processes
+ * @return
+ */
+LogFunction restrictedLogFunction(Log level, Log restriction) {
+    if (level <= restriction) {
+        // Lower log levels are more important
+        return printMessage;
+    } else {
+        return printMessage0;
+    }
+}
+
+}  // namespace
+
+void initDGMaxLogging(Log restrict, bool useCommandLine) {
     time(&initTime);
 #ifdef HPGEM_USE_MPI
     MPI_Comm_rank(MPI_COMM_WORLD, &commRank);
@@ -53,12 +123,40 @@ void initDGMaxLogging() {
         log10CommSize++;
         commSize /= 10;
     }
+    if (useCommandLine && restrictionOption != nullptr &&
+        restrictionOption->isUsed()) {
+        if (!restrictionOption->hasArgument()) {
+            logger(WARN, "Command line log level requires an argument");
+        }
+        // Convert to lower case for user friendlyness
+        std::string value = restrictionOption->getValue();
+        std::transform(value.begin(), value.end(), value.begin(),
+                       [](unsigned char c) { return std::tolower(c); });
+        if (value == "error") {
+            restrict = Log::ERROR;
+        } else if (value == "warn") {
+            restrict = Log::WARN;
+        } else if (value == "info") {
+            restrict = Log::INFO;
+        } else if (value == "verbose") {
+            restrict = Log::VERBOSE;
+        } else if (value == "debug") {
+            restrict = Log::DEBUG;
+        } else {
+            logger(WARN, "Unknown value for logger restriction %",
+                   restrictionOption->getValue());
+        }
+    }
+
 #endif
     static LoggerOutput output = {
-        // Keep the error as original, it prints stacktraces.
-        loggerOutput->onError,
-        printMessage,   // Warnings are important for each processor
-        printMessage0,  // Info, Verbose and Debug only on the first processor
-        printMessage0, printMessage0};
+        // Keep the fatal and error as original, it prints stacktraces.
+        loggerOutput->onFatal, loggerOutput->onError,
+        restrictedLogFunction(Log::WARN, restrict),
+        restrictedLogFunction(Log::INFO, restrict),
+        restrictedLogFunction(Log::VERBOSE, restrict),
+        restrictedLogFunction(Log::DEBUG, restrict),
+        // Don't override the failure handler
+        loggerOutput->onFail};
     loggerOutput = &output;
 }

--- a/applications/DG-Max/DGMaxLogger.h
+++ b/applications/DG-Max/DGMaxLogger.h
@@ -1,3 +1,40 @@
+/*
+ This file forms part of hpGEM. This package has been developed over a number of
+ years by various people at the University of Twente and a full list of
+ contributors can be found at http://hpgem.org/about-the-code/team
+
+ This code is distributed using BSD 3-Clause License. A copy of which can found
+ below.
+
+
+ Copyright (c) 2018, University of Twente
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice, this
+ list of conditions and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation
+ and/or other materials provided with the distribution.
+
+ 3. Neither the name of the copyright holder nor the names of its contributors
+ may be used to endorse or promote products derived from this software without
+ specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 #ifndef HPGEM_APP_DGMAXLOGGER_H
 #define HPGEM_APP_DGMAXLOGGER_H
 
@@ -7,7 +44,25 @@ using namespace hpgem;
 
 extern Logger<HPGEM_LOGLEVEL> DGMaxLogger;
 
-void initDGMaxLogging();
+/**
+ * Register a command line flag handler for setting the log level below which
+ * log messages are restricted to the first MPI process. Note: Must be called
+ * before Base::parse_options to be effective.
+ */
+void registerLogLevelCommandLineFlag();
+
+/**
+ * Init the logger for DGMax formatted output.
+ *
+ * This includes modifying the output to print the elapsed time. Additionally
+ * for MPI the rank of the logging process is printed and low important log
+ * messages will be suppressed from all but the first process.
+ *
+ * @param restrict The level below which to restrict the log messages to all but
+ * the first process.
+ * @param useCommandLine Use the value from the command line if available
+ */
+void initDGMaxLogging(Log restrict = Log::WARN, bool useCommandLine = true);
 void logAll(std::function<void()> log);
 bool loggingSuppressed();
 

--- a/applications/DG-Max/Programs/DGMaxEigen.cpp
+++ b/applications/DG-Max/Programs/DGMaxEigen.cpp
@@ -93,6 +93,7 @@ template <std::size_t DIM>
 void writeMesh(std::string fileName, const Base::MeshManipulator<DIM>* mesh);
 
 int main(int argc, char** argv) {
+    registerLogLevelCommandLineFlag();
     Base::parse_options(argc, argv);
     initDGMaxLogging();
     DGMax::printArguments(argc, argv);


### PR DESCRIPTION
Repeating the (almost) identical log output from multiple MPI processes will only clutter the output. However, for debugging it may be useful to see the log output from all of them. This commit adds an option --mpiloglevel allowing switching which messages get outputted by all processes.