### PR TITLE
Dgmax face integrals mpi fix

### DIFF
--- a/applications/DG-Max/Algorithms/DGMaxDiscretization.cpp
+++ b/applications/DG-Max/Algorithms/DGMaxDiscretization.cpp
@@ -156,14 +156,8 @@ void DGMaxDiscretization<DIM>::computeFaceIntegralsImpl(
         std::shared_ptr<Base::CoordinateTransformation<DIM>>(
             new Base::HCurlConformingTransformation<DIM>()));
     auto end = mesh.faceColEnd();
-    for (typename Base::MeshManipulator<DIM>::FaceIterator it =
-             mesh.faceColBegin();
-         it != end; ++it) {
+    for (auto it = mesh.faceColBegin(); it != end; ++it) {
         Base::Face* face = *it;
-        if (!face->isOwnedByCurrentProcessor()) {
-            // Not interested in non-owned faces
-            continue;
-        }
 
         if (integrals == LocalIntegrals::ALL) {
             computeFaceMatrix(face, boundaryIndicator);

--- a/applications/DG-Max/Utils/CGDGMatrixKPhaseShiftBuilder.cpp
+++ b/applications/DG-Max/Utils/CGDGMatrixKPhaseShiftBuilder.cpp
@@ -177,6 +177,14 @@ void CGDGMatrixKPhaseShiftBuilder<DIM>::addElementPhaseShift(
     // If the owning element and the current element are not on different sides
     // of the periodic boundary, then dx = a_T = 0 and there is no phase shift.
     if (dx.l2Norm() > 1e-12) {
+        std::size_t numProjectorDoF = geom->getLocalNumberOfBasisFunctions(1);
+        if (numProjectorDoF == 0) {
+            // The basis functions for this geometry part need to be shifted,
+            // but there are none. This is primarily the case with lower order
+            // basis functions.
+            return;
+        }
+
         const Geometry::PointReference<DIM>& center =
             element->getReferenceGeometry()->getCenter();
 
@@ -186,8 +194,6 @@ void CGDGMatrixKPhaseShiftBuilder<DIM>::addElementPhaseShift(
             // trial basis functions use the - sign.
             dx -= extraShift_(element);
         }
-
-        std::size_t numProjectorDoF = geom->getLocalNumberOfBasisFunctions(1);
 
         // Difference in coordinates for the node => shift is needed
         std::size_t numSolutionDoF = element->getLocalNumberOfBasisFunctions(0);

--- a/applications/DG-Max/Utils/FaceKPhaseShiftBuilder.cpp
+++ b/applications/DG-Max/Utils/FaceKPhaseShiftBuilder.cpp
@@ -102,8 +102,8 @@ KPhaseShiftBlock<DIM> FaceMatrixKPhaseShiftBuilder<DIM>::facePhaseShift(
     // The face is a periodic boundary, but could also be a subdomain boundary.
     // For a non-subdomain boundary the current processor is responsible for
     // both off diagonal blocks in the face matrix. On a subdomain boundary it
-    // is only responsible of the off diagonal block that has locally owned rows
-    // (i.e. test functions).
+    // is only responsible for the off diagonal block that has locally owned
+    // rows (i.e. test functions).
     bool isSubdomainBoundary;
     // Element that this processor owns
     const Base::Element* ownedElement = face->getPtrElementLeft();

--- a/applications/DG-Max/Utils/KPhaseShiftHelpers.h
+++ b/applications/DG-Max/Utils/KPhaseShiftHelpers.h
@@ -47,7 +47,7 @@ using namespace hpgem;
 
 // Several helper functions needed for implemting KPhase shifts
 
-inline void checkMatrixSize(const LinearAlgebra::MiddleSizeMatrix mat,
+inline void checkMatrixSize(const LinearAlgebra::MiddleSizeMatrix& mat,
                             std::size_t rows, std::size_t cols) {
     logger.assert_always(mat.getNumberOfRows() == rows,
                          "Incorrect number of rows, expected % got %", rows,


### PR DESCRIPTION
Fixes to get DGMaxDiscretization to work with MPI meshes. Partially undoing overzealos fix in #173.