### PR TITLE
Fix the configuration of the formatter

### DIFF
--- a/applications/Preprocessor/lib/FortranUnformattedFile.cpp
+++ b/applications/Preprocessor/lib/FortranUnformattedFile.cpp
@@ -52,7 +52,8 @@ void FortranUnformattedFile::readRawRecord(std::uint32_t size, char *buffer) {
     logger.assert_debug(readRecordSize(recordSize),
                         "record size reading failed.");
     logger.assert_debug(recordSize == size,
-                        "Record size (%) does not match expected size (%)", recordSize, size);
+                        "Record size (%) does not match expected size (%)",
+                        recordSize, size);
     // Read content
     std::streamsize read = file_.sgetn(buffer, recordSize);
     logger.assert_debug(read == recordSize, "Incomplete record read");

--- a/conf/cmake/ConfigureDependencies.cmake
+++ b/conf/cmake/ConfigureDependencies.cmake
@@ -97,13 +97,13 @@ if(CLANG_FORMAT_FOUND)
         file(GLOB_RECURSE format_files_dir
                 ${CMAKE_CURRENT_SOURCE_DIR}/${sourcedir}/*.cpp
                 ${CMAKE_CURRENT_SOURCE_DIR}/${sourcedir}/*.h)
-        list(APPEND formatfiles ${format_files_dir})
-        list(LENGTH formatfiles nff)
+        list(APPEND format_files ${format_files_dir})
+        list(LENGTH format_files nff)
         message(STATUS "Formatting ${nff} files")
     endforeach()
     list(LENGTH FORMAT_SOURCES nff)
     message(STATUS "Formatting ${nff} files")
     add_custom_target(format
-        COMMAND ${CLANG_FORMAT_EXECUTABLE} -i -style=file ${FORMAT_SOURCES}
+        COMMAND ${CLANG_FORMAT_EXECUTABLE} -i -style=file ${format_files}
         DEPENDS ${format_files})
 endif()

--- a/kernel/Geometry/ElementGeometry.h
+++ b/kernel/Geometry/ElementGeometry.h
@@ -270,7 +270,9 @@ inline MappingReferenceToPhysicalBase* ElementGeometry::createMappings(
             logger(VERBOSE, "ElementGeometry created a mapping for a cube.");
             return new Geometry::MappingToPhysHypercubeLinear<3>(pGeo);
         case 10:
-            logger(VERBOSE, "ElementGeometry created a mapping for a quadratic tetrahedron.");
+            logger(VERBOSE,
+                   "ElementGeometry created a mapping for a quadratic "
+                   "tetrahedron.");
             return new Geometry::MappingToPhysTetrahedronQuadratic(pGeo);
     }
     logger(FATAL, "No know entities contain this many nodes. \n");

--- a/kernel/Geometry/Mappings/MappingRefLineToTetrahedron.cpp
+++ b/kernel/Geometry/Mappings/MappingRefLineToTetrahedron.cpp
@@ -48,13 +48,13 @@ MappingRefLineToTetrahedron::MappingRefLineToTetrahedron(
     const auto& node2 = nodes[nodesOnEdges[face][1]].getCoordinates();
     basis_ = (node1 + node2) / 2.0;
     auto dir = (node2 - node1) / 2.0;
-    for(std::size_t i = 0; i < 3; ++i) {
+    for (std::size_t i = 0; i < 3; ++i) {
         jacobian_(i, 0) = dir[i];
     }
 }
 
 Geometry::PointReference<3> MappingRefLineToTetrahedron::transform(
-    const Geometry::PointReference<1> &p) const {
+    const Geometry::PointReference<1>& p) const {
     Geometry::PointReference<3> result(basis_);
     for (std::size_t i = 0; i < 3; ++i) {
         result[i] += jacobian_[i] * p[0];
@@ -63,7 +63,7 @@ Geometry::PointReference<3> MappingRefLineToTetrahedron::transform(
 }
 
 Geometry::Jacobian<1, 3> MappingRefLineToTetrahedron::calcJacobian(
-    const PointReference<1> &) const {
+    const PointReference<1>&) const {
     return jacobian_;
 }
 

--- a/kernel/Geometry/Mappings/MappingRefLineToTetrahedron.h
+++ b/kernel/Geometry/Mappings/MappingRefLineToTetrahedron.h
@@ -54,9 +54,7 @@ class MappingRefLineToTetrahedron : public MappingReferenceToReference<2> {
         const Geometry::PointReference<1>&) const final;
     Geometry::Jacobian<1, 3> calcJacobian(const PointReference<1>&) const final;
 
-    size_t getTargetDimension() const override {
-        return 3;
-    }
+    size_t getTargetDimension() const override { return 3; }
 
    private:
     LinearAlgebra::SmallVector<3> basis_;

--- a/kernel/Geometry/Mappings/MappingToPhysTetrahedronQuadratic.h
+++ b/kernel/Geometry/Mappings/MappingToPhysTetrahedronQuadratic.h
@@ -56,7 +56,6 @@ class MappingToPhysTetrahedronQuadratic : public MappingReferenceToPhysical<3> {
     PointPhysical<3> transform(const PointReference<3>& p) const final;
     PointReference<3> inverseTransform(const PointPhysical<3>& p) const final;
     Jacobian<3, 3> calcJacobian(const PointReference<3>& p) const final;
-
 };
 
 }  // namespace Geometry


### PR DESCRIPTION
A typo accidentally meant that the formatting always crashed without
doing anything.