### PR TITLE
Clang format 11

### DIFF
--- a/.github/workflows/checkformat.yml
+++ b/.github/workflows/checkformat.yml
@@ -14,7 +14,7 @@ jobs:
     - name: dependencies
       run: |
         sudo apt update
-        sudo apt-get install libblas-dev liblapack-dev libopenmpi-dev clang-format-10
+        sudo apt-get install libblas-dev liblapack-dev libopenmpi-dev clang-format-11
     - name: cmake
       run: cmake -B builddir
     - name: Format

--- a/applications/DG-Max/ProblemTypes/Harmonic/SampleHarmonicProblems.h
+++ b/applications/DG-Max/ProblemTypes/Harmonic/SampleHarmonicProblems.h
@@ -90,8 +90,8 @@ class [[maybe_unused]] SarmanyHarmonicProblem
     LinearAlgebra::SmallVectorC<3> exactSolutionCurl(
         const Geometry::PointPhysical<3>& point) const override;
     LinearAlgebra::SmallVectorC<3> sourceTerm(
-        const Base::Element&, const Geometry::PointPhysical<3>& point)
-        const override;
+        const Base::Element&,
+        const Geometry::PointPhysical<3>& point) const override;
 
    private:
     double omega_;

--- a/conf/cmake/ConfigureDependencies.cmake
+++ b/conf/cmake/ConfigureDependencies.cmake
@@ -90,7 +90,7 @@ if(hpGEM_USE_SLEPC)
     add_definitions(-DHPGEM_USE_SLEPC)
 endif()
 
-find_package(CLANG_FORMAT 10 EXACT)
+find_package(CLANG_FORMAT 11.1 EXACT)
 if(CLANG_FORMAT_FOUND)
     set(format_files)
     foreach(sourcedir kernel tests applications)

--- a/conf/cmake/ConfigureDependencies.cmake
+++ b/conf/cmake/ConfigureDependencies.cmake
@@ -98,11 +98,11 @@ if(CLANG_FORMAT_FOUND)
                 ${CMAKE_CURRENT_SOURCE_DIR}/${sourcedir}/*.cpp
                 ${CMAKE_CURRENT_SOURCE_DIR}/${sourcedir}/*.h)
         list(APPEND format_files ${format_files_dir})
-        list(LENGTH format_files nff)
-        message(STATUS "Formatting ${nff} files")
+        list(LENGTH format_files_dir nff)
+        message(STATUS "Formatting ${nff} files in ${sourcedir}")
     endforeach()
-    list(LENGTH FORMAT_SOURCES nff)
-    message(STATUS "Formatting ${nff} files")
+    list(LENGTH format_files nff)
+    message(STATUS "Formatting ${nff} files (total)")
     add_custom_target(format
         COMMAND ${CLANG_FORMAT_EXECUTABLE} -i -style=file ${format_files}
         DEPENDS ${format_files})

--- a/conf/cmake/ConfigureDependencies.cmake
+++ b/conf/cmake/ConfigureDependencies.cmake
@@ -90,7 +90,7 @@ if(hpGEM_USE_SLEPC)
     add_definitions(-DHPGEM_USE_SLEPC)
 endif()
 
-find_package(CLANG_FORMAT 11.1 EXACT)
+find_package(CLANG_FORMAT 11)
 if(CLANG_FORMAT_FOUND)
     set(format_files)
     foreach(sourcedir kernel tests applications)

--- a/conf/cmake/Modules/FindCLANG_FORMAT.cmake
+++ b/conf/cmake/Modules/FindCLANG_FORMAT.cmake
@@ -31,12 +31,13 @@ find_program(CLANG_FORMAT_EXECUTABLE
              DOC "clang-format executable")
 mark_as_advanced(CLANG_FORMAT_EXECUTABLE)
 
+message("Clang format executable found at ${CLANG_FORMAT_EXECUTABLE}")
 # Extract version from command "clang-format -version"
 if(CLANG_FORMAT_EXECUTABLE)
   execute_process(COMMAND ${CLANG_FORMAT_EXECUTABLE} -version
                   OUTPUT_VARIABLE clang_format_version
                   ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
-
+  message("Found clang-format reports version ${clang_format_version}")
   if(clang_format_version MATCHES "^clang-format version .*")
     # clang_format_version sample: "clang-format version 3.9.1-4ubuntu3~16.04.1
     # (tags/RELEASE_391/rc2)"

--- a/conf/cmake/Modules/FindCLANG_FORMAT.cmake
+++ b/conf/cmake/Modules/FindCLANG_FORMAT.cmake
@@ -21,8 +21,9 @@
 # from http://github.com/votca/votca/blob/master/CMakeModules/FindCLANG_FORMAT.cmake
 
 find_program(CLANG_FORMAT_EXECUTABLE
-             NAMES clang-format-10
-	           clang-format
+             NAMES clang-format-11
+                   clang-format-10
+	               clang-format
                    clang-format-9
                    clang-format-8
                    clang-format-7

--- a/conf/cmake/Modules/FindCLANG_FORMAT.cmake
+++ b/conf/cmake/Modules/FindCLANG_FORMAT.cmake
@@ -38,11 +38,11 @@ if(CLANG_FORMAT_EXECUTABLE)
                   OUTPUT_VARIABLE clang_format_version
                   ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
   message("Found clang-format reports version ${clang_format_version}")
-  if(clang_format_version MATCHES "^clang-format version .*")
+  if(clang_format_version MATCHES "^.*clang-format version .*")
     # clang_format_version sample: "clang-format version 3.9.1-4ubuntu3~16.04.1
     # (tags/RELEASE_391/rc2)"
     string(REGEX
-           REPLACE "clang-format version ([.0-9]+).*"
+           REPLACE "^.*clang-format version ([.0-9]+).*"
                    "\\1"
                    CLANG_FORMAT_VERSION
                    "${clang_format_version}")

--- a/kernel/AbstractDimensionlessBase.h
+++ b/kernel/AbstractDimensionlessBase.h
@@ -102,26 +102,26 @@ class AbstractDimensionlessBase {
     // clang-tidy warnings about the implicit conversions.
 
     // NOLINTNEXTLINE(google-explicit-constructor)
-    operator TypeWithDim<0> &() { return castDimension<0>(); }
+    operator TypeWithDim<0>&() { return castDimension<0>(); }
     // NOLINTNEXTLINE(google-explicit-constructor)
-    operator TypeWithDim<1> &() { return castDimension<1>(); }
+    operator TypeWithDim<1>&() { return castDimension<1>(); }
     // NOLINTNEXTLINE(google-explicit-constructor)
-    operator TypeWithDim<2> &() { return castDimension<2>(); }
+    operator TypeWithDim<2>&() { return castDimension<2>(); }
     // NOLINTNEXTLINE(google-explicit-constructor)
-    operator TypeWithDim<3> &() { return castDimension<3>(); }
+    operator TypeWithDim<3>&() { return castDimension<3>(); }
     // NOLINTNEXTLINE(google-explicit-constructor)
-    operator TypeWithDim<4> &() { return castDimension<4>(); }
+    operator TypeWithDim<4>&() { return castDimension<4>(); }
 
     // NOLINTNEXTLINE(google-explicit-constructor)
-    operator const TypeWithDim<0> &() const { return castDimension<0>(); }
+    operator const TypeWithDim<0>&() const { return castDimension<0>(); }
     // NOLINTNEXTLINE(google-explicit-constructor)
-    operator const TypeWithDim<1> &() const { return castDimension<1>(); }
+    operator const TypeWithDim<1>&() const { return castDimension<1>(); }
     // NOLINTNEXTLINE(google-explicit-constructor)
-    operator const TypeWithDim<2> &() const { return castDimension<2>(); }
+    operator const TypeWithDim<2>&() const { return castDimension<2>(); }
     // NOLINTNEXTLINE(google-explicit-constructor)
-    operator const TypeWithDim<3> &() const { return castDimension<3>(); }
+    operator const TypeWithDim<3>&() const { return castDimension<3>(); }
     // NOLINTNEXTLINE(google-explicit-constructor)
-    operator const TypeWithDim<4> &() const { return castDimension<4>(); }
+    operator const TypeWithDim<4>&() const { return castDimension<4>(); }
 
     /// \brief Fast conversion to implementation type with dimension.
     ///


### PR DESCRIPTION
Switch from clang format 10 to 11.1. The version 10 is no longer available as mac brew, and also not available on the newer ubuntu CI vms.