### PR TITLE
Fix gmsh reading of multiple periodic boundaries

### DIFF
--- a/applications/Preprocessor/lib/gmsh.h
+++ b/applications/Preprocessor/lib/gmsh.h
@@ -62,11 +62,15 @@ class GmshReader final : public MeshSource2 {
    public:
     GmshReader(std::string filename);
 
-    const std::vector<Coord>& getCoordinates() { return nodes_; }
+    const std::vector<Coord>& getCoordinates() final { return nodes_; }
 
-    const std::vector<Element>& getElements() { return elements_; }
+    const std::vector<Element>& getElements() final { return elements_; }
 
-    std::size_t getDimension() const { return dimension_; }
+    const std::vector<std::map<std::size_t, std::size_t>>& getMerges() final {
+        return coordinateMerges_;
+    };
+
+    std::size_t getDimension() const final { return dimension_; }
 
    private:
     // Element as used by gmsh
@@ -135,6 +139,10 @@ class GmshReader final : public MeshSource2 {
     std::ifstream Filehandle_;
     std::map<size_t, size_t> nodesPerElementtype_;
     std::map<size_t, size_t> dimensionOfElementtype_;
+    /**
+     * A series of coordinate identifications from periodic boundary conditions.
+     */
+    std::vector<std::map<std::size_t, std::size_t>> coordinateMerges_;
 };
 
 }  // namespace Preprocessor

--- a/tests/unit/Preprocessor/001gmsh_UnitTest.cpp
+++ b/tests/unit/Preprocessor/001gmsh_UnitTest.cpp
@@ -69,16 +69,16 @@ TEST_CASE("ReadingFile", "[ReadingFile]") {
         }
     }
 
-    // Check periodic connections (Note: Fortran offset)
+    // Check periodic connections
     // 5 - 1
     // 6 - 4
     std::vector<std::pair<std::size_t, std::size_t>> mergedNodes = {
+        // Note difference due to Fortran offset
         {4, 0},
-        {5, 3}
-    };
+        {5, 3}};
     const auto& actualMerges = reader.getMerges();
     CHECK(actualMerges.size() == 1);
-    for(const auto& p : mergedNodes) {
+    for (const auto& p : mergedNodes) {
         const auto pf = actualMerges[0].find(p.first);
         REQUIRE(pf != actualMerges[0].end());
         REQUIRE(pf->second == p.second);

--- a/tests/unit/Preprocessor/001gmsh_UnitTest.cpp
+++ b/tests/unit/Preprocessor/001gmsh_UnitTest.cpp
@@ -53,8 +53,8 @@ TEST_CASE("ReadingFile", "[ReadingFile]") {
     ref_Coords.push_back({1, {1.0, 0.0}});
     ref_Coords.push_back({2, {1.0, 1.0}});
     ref_Coords.push_back({3, {0.0, 1.0}});
-    ref_Coords.push_back({0, {2.0, 0.0}});
-    ref_Coords.push_back({3, {2.0, 1.0}});
+    ref_Coords.push_back({4, {2.0, 0.0}});
+    ref_Coords.push_back({5, {2.0, 1.0}});
 
     const auto& coords = reader.getCoordinates();
     INFO("Nodes");
@@ -67,6 +67,21 @@ TEST_CASE("ReadingFile", "[ReadingFile]") {
             REQUIRE(coords[i].coordinate[dim] ==
                     Approx(ref_Coords[i].coordinate[dim]));
         }
+    }
+
+    // Check periodic connections (Note: Fortran offset)
+    // 5 - 1
+    // 6 - 4
+    std::vector<std::pair<std::size_t, std::size_t>> mergedNodes = {
+        {4, 0},
+        {5, 3}
+    };
+    const auto& actualMerges = reader.getMerges();
+    CHECK(actualMerges.size() == 1);
+    for(const auto& p : mergedNodes) {
+        const auto pf = actualMerges[0].find(p.first);
+        REQUIRE(pf != actualMerges[0].end());
+        REQUIRE(pf->second == p.second);
     }
 
     std::vector<Preprocessor::MeshSource2::Element> ref_Elements;
@@ -120,6 +135,8 @@ TEST_CASE("ReadingFile_NOPBC", "[ReadingFile]") {
                     Approx(ref_Coords[i].coordinate[dim]));
         }
     }
+
+    REQUIRE(reader.getMerges().empty());
 
     std::vector<Preprocessor::MeshSource2::Element> ref_Elements;
     ref_Elements.reserve(2);


### PR DESCRIPTION
The gmsh reader incorrectly interpreted the number of periodic entities number. As result it did not correctly read the case with >1 periodic entities.

This commit fixes this issue, and migrates the handling of periodic entities to the new style. That is, specify the periodic connections rather than directly merging node coordinates.