### PR TITLE
Print full precision in DGMaxEigen

### DIFF
--- a/.github/workflows/PETSC_complex.yml
+++ b/.github/workflows/PETSC_complex.yml
@@ -21,7 +21,7 @@ jobs:
     - name: dependencies
       run: |
         sudo apt update
-        sudo apt install libblas-dev liblapack-dev libopenmpi-dev libpetsc-complex-dev libslepc-complex3.12-dev
+        sudo apt install libblas-dev liblapack-dev libopenmpi-dev libpetsc-complex-dev libslepc-complex3.15-dev
     - name: configure
       env:
         CC: ${{ matrix.compiler }}

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -19,7 +19,7 @@ jobs:
     - name: blaslapack
       run: |
         sudo apt update
-        sudo apt install libblas-dev liblapack-dev libopenmpi-dev libmetis-dev libpetsc-complex-dev libslepc-complex3.12-dev
+        sudo apt install libblas-dev liblapack-dev libopenmpi-dev libmetis-dev libpetsc-complex-dev libslepc-complex3.15-dev
     - name: configure
       env:
         CC: ${{ matrix.compiler }}

--- a/applications/DG-Max/Programs/DGMaxEigen.cpp
+++ b/applications/DG-Max/Programs/DGMaxEigen.cpp
@@ -1,5 +1,6 @@
 
 #include <exception>
+#include <iomanip>
 #include "Base/CommandLineOptions.h"
 #include "Base/MeshFileInformation.h"
 #include "Output/VTKSpecificTimeWriter.h"
@@ -245,6 +246,7 @@ class DGMaxEigenDriver : public AbstractEigenvalueSolverDriver<DIM> {
                << separator << k[0] / (2*M_PI)
                << separator << k[1] / (2*M_PI)
                << separator << (DIM == 3 ?  k[2] / (2*M_PI) : 0)
+               << std::setprecision(16)
                << separator << k.l2Norm() / (2*M_PI);
         // clang-format on
 
@@ -255,6 +257,8 @@ class DGMaxEigenDriver : public AbstractEigenvalueSolverDriver<DIM> {
             // c=1, and assume the length scale a matches that of the mesh. Thus
             // the distance between x=0 and x=1 is assumed to be 'a'.
             stream << separator
+                   // Full precision to allow convergence analysis
+                   << std::setprecision(16)
                    << frequency / (2 * M_PI) * lengthScale.getValue();
         }
         stream << std::endl;


### PR DESCRIPTION
Print both kmag and eigenfrequencies in full precision. This is needed with very accurate convergence tests. Note, kx, ky, kz are not printed in full precision as these are input (or interpolated).