### PR TITLE
Fix KPhaseShift adding edges/nodes

### DIFF
--- a/applications/DG-Max/Utils/CGDGMatrixKPhaseShiftBuilder.cpp
+++ b/applications/DG-Max/Utils/CGDGMatrixKPhaseShiftBuilder.cpp
@@ -93,15 +93,14 @@ KPhaseShifts<DIM> CGDGMatrixKPhaseShiftBuilder<DIM>::build(
                 }
             }
         }
-
-        // Now that all boundary nodes and edges have been de-duplicated, add
-        // their shifts.
-        for (const Base::Node* node : boundaryNodes) {
-            this->addNodePhaseShifts(node, cgIndexing, dgIndexing, result);
-        }
-        for (const Base::Edge* edge : boundaryEdges) {
-            this->addEdgePhaseShifts(edge, cgIndexing, dgIndexing, result);
-        }
+    }
+    // Now that all boundary nodes and edges have been de-duplicated, add
+    // their shifts.
+    for (const Base::Node* node : boundaryNodes) {
+        this->addNodePhaseShifts(node, cgIndexing, dgIndexing, result);
+    }
+    for (const Base::Edge* edge : boundaryEdges) {
+        this->addEdgePhaseShifts(edge, cgIndexing, dgIndexing, result);
     }
     return KPhaseShifts<DIM>(result);
 }


### PR DESCRIPTION
They were added in the loop, such that each edge/node was added on multiple times instead of only once.

Cherry-pick: Needed to add the indexing

--
Old fix that did not get into master