### PR TITLE
Fix curvilinear node basis functions

### DIFF
--- a/kernel/Base/MeshManipulator_Impl.h
+++ b/kernel/Base/MeshManipulator_Impl.h
@@ -678,15 +678,21 @@ void MeshManipulator<DIM>::useDefaultConformingBasisFunctions(
         }
         for (Node *node : getNodesList(IteratorType::GLOBAL)) {
             if (DIM > 1) {
+                if (node->getTopologicalNodeNumber(0) < 0) {
+                    // Geometric node for curvilinear elements;
+                    continue;
+                }
                 for (std::size_t i = 0; i < node->getNumberOfElements(); ++i) {
                     Element *element = node->getElement(i);
-                    std::size_t nodeNumber = node->getNodeNumber(i);
+                    auto nodeNumber = node->getTopologicalNodeNumber(i);
+                    logger.assert_debug(nodeNumber >= 0,
+                                        "Inconsistent use of a geometric node");
                     auto type =
                         element->getReferenceGeometry()->getGeometryType();
                     element->setVertexBasisFunctionSet(
                         shapeToElementIndex[type] + numberOfFaceSets[type] +
                             numberOfEdgeSets[type] + 1 + nodeNumber,
-                        nodeNumber);
+                        node->getNodeNumber(i));
                     node->setLocalNumberOfBasisFunctions(
                         collBasisFSet_[shapeToElementIndex[type] +
                                        numberOfFaceSets[type] +
@@ -985,14 +991,20 @@ void MeshManipulator<DIM>::useDefaultConformingBasisFunctions(
     }
     for (Node *node : getNodesList(IteratorType::GLOBAL)) {
         if (DIM > 1) {
+            if (node->getTopologicalNodeNumber(0) < 0) {
+                // Geometric node for curvilinear elements;
+                continue;
+            }
             for (std::size_t i = 0; i < node->getNumberOfElements(); ++i) {
                 Element *element = node->getElement(i);
-                std::size_t nodeNumber = node->getNodeNumber(i);
+                auto nodeNumber = node->getTopologicalNodeNumber(i);
+                logger.assert_debug(nodeNumber >= 0,
+                                    "Inconsistent use of a geometric node");
                 auto type = element->getReferenceGeometry()->getGeometryType();
                 element->setVertexBasisFunctionSet(
                     shapeToElementIndex[type] + numberOfFaceSets[type] +
                         numberOfEdgeSets[type] + 1 + nodeNumber,
-                    nodeNumber, unknown);
+                    node->getNodeNumber(i), unknown);
                 const_cast<ConfigurationData *>(configData_)
                     ->numberOfBasisFunctions_ +=
                     collBasisFSet_[shapeToElementIndex[type] +
@@ -1043,9 +1055,16 @@ void MeshManipulator<DIM>::addVertexBasisFunctionSet(
         collBasisFSet_.emplace_back(set);
     }
     for (Node *node : getNodesList()) {
+        if (node->getTopologicalNodeNumber(0) < 0) {
+            // Geometric node for curvilinear elements;
+            continue;
+        }
         for (std::size_t i = 0; i < node->getNumberOfElements(); ++i) {
+            auto nodeNumber = node->getTopologicalNodeNumber(i);
+            logger.assert_debug(nodeNumber >= 0,
+                                "Inconsistent use of a geometric node");
             node->getElement(i)->setVertexBasisFunctionSet(
-                firstNewEntry + node->getNodeNumber(i), node->getNodeNumber(i));
+                firstNewEntry + nodeNumber, node->getNodeNumber(i));
         }
         node->setLocalNumberOfBasisFunctions(bFsets[0]->size());
     }

--- a/kernel/Base/Node.cpp
+++ b/kernel/Base/Node.cpp
@@ -134,6 +134,14 @@ const std::vector<Base::Face *> Base::Node::getFaces() const {
     return ptrFacesAtNode;
 }
 
+long long Base::Node::getTopologicalNodeNumber(std::size_t i) const {
+    logger.assert_debug(i < getNumberOfElements(),
+                        "Asked for element %, but there are only % elements", i,
+                        getNumberOfElements());
+    return elements_[i]->getReferenceGeometry()->getTopologicalLocalIndex(
+        localNodeNumbers_[i]);
+}
+
 bool Base::Node::isOwnedByCurrentProcessor() const {
     return elements_.size() > 0 && elements_[0]->isOwnedByCurrentProcessor();
 }

--- a/kernel/Base/Node.h
+++ b/kernel/Base/Node.h
@@ -136,6 +136,10 @@ class Node {
         return localNodeNumbers_[i];
     }
 
+    /// Get the local node number for this node if it is a topological node or
+    /// -1 if it is a node purely for the curvilinear geometry.
+    long long getTopologicalNodeNumber(std::size_t i) const;
+
     void setLocalNumberOfBasisFunctions(std::size_t number) {
         for (std::size_t unknown = 0;
              unknown < numberOfConformingDOFOnTheNode_.size(); ++unknown) {

--- a/kernel/Geometry/ReferenceCurvilinearElement.h
+++ b/kernel/Geometry/ReferenceCurvilinearElement.h
@@ -131,8 +131,8 @@ class ReferenceCurvilinearElement : public ReferenceCurvilinearElementBase {
     std::size_t getNumberOfNodes() const final { return points_.size(); }
 
     long long getTopologicalLocalIndex(std::size_t localIndex) const override {
-        for(long long i = 0; i < baseGeometryIndicices_.size(); ++i) {
-            if(baseGeometryIndicices_[i] == localIndex) {
+        for (long long i = 0; i < baseGeometryIndicices_.size(); ++i) {
+            if (baseGeometryIndicices_[i] == localIndex) {
                 return i;
             }
         }

--- a/kernel/Geometry/ReferenceCurvilinearElement.h
+++ b/kernel/Geometry/ReferenceCurvilinearElement.h
@@ -55,6 +55,7 @@ class ReferenceCurvilinearElementBase : public ReferenceGeometry {
     /// The linear version of this curvilinear element
     /// \return
     virtual ReferenceGeometry* getBaseGeometry() const = 0;
+
     /// The polynomial order of this curvilinear element
     std::size_t getOrder() const { return order_; }
 
@@ -128,6 +129,15 @@ class ReferenceCurvilinearElement : public ReferenceCurvilinearElementBase {
     }
 
     std::size_t getNumberOfNodes() const final { return points_.size(); }
+
+    long long getTopologicalLocalIndex(std::size_t localIndex) const override {
+        for(long long i = 0; i < baseGeometryIndicices_.size(); ++i) {
+            if(baseGeometryIndicices_[i] == localIndex) {
+                return i;
+            }
+        }
+        return -1;
+    }
 
     const PointReference<dim>& getReferenceNodeCoordinate(
         const std::size_t& localIndex) const final {

--- a/kernel/Geometry/ReferenceGeometry.h
+++ b/kernel/Geometry/ReferenceGeometry.h
@@ -165,6 +165,13 @@ class ReferenceGeometry : public MappingCodimensions {
     virtual const PointReferenceBase& getReferenceNodeCoordinate(
         const std::size_t& localIndex) const = 0;
 
+    /// For a given local index of a reference point, get the index of the
+    /// corresponding node in the BaseGeometry, or -1 if it is purely a node
+    /// in a curvilinear element.
+    virtual long long getTopologicalLocalIndex(std::size_t localIndex) const {
+        return localIndex;
+    }
+
     std::size_t getLocalNodeIndexFromFaceAndIndexOnFace(
         std::size_t face, std::size_t node) const {
         logger.assert_debug(face < getNumberOfCodim1Entities(),

--- a/tests/self/Basic/010HigherOrderElementsOnCurvilinear.cpp
+++ b/tests/self/Basic/010HigherOrderElementsOnCurvilinear.cpp
@@ -1,0 +1,72 @@
+/*
+This file forms part of hpGEM. This package has been developed over a number of
+years by various people at the University of Twente and a full list of
+contributors can be found at http://hpgem.org/about-the-code/team
+
+This code is distributed using BSD 3-Clause License. A copy of which can found
+below.
+
+
+Copyright (c) 2023, University of Twente
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "Base/MeshManipulator.h"
+#include "Base/ConfigurationData.h"
+
+#include "Base/CommandLineOptions.h"
+#include "Logger.h"
+#include <hpgem-cmake.h>
+
+using namespace hpgem;
+
+int main(int argc, char** argv) {
+    using namespace std::string_literals;
+    Base::parse_options(argc, argv);
+
+    Base::MeshManipulator<2> mesh(new Base::ConfigurationData(2, 0));
+    mesh.readMesh(getCMAKE_hpGEM_SOURCE_DIR() +
+                  "/tests/files/circle-domain-quadratic-N1.hpgem"s);
+    // Set lots of basis functions, but there should be only 2 per topological
+    // node
+    mesh.useDefaultConformingBasisFunctions(4);
+    mesh.useDefaultConformingBasisFunctions(4, 1);
+
+    for (Base::Node* node : mesh.getNodesList()) {
+        bool isTopoNode = node->getTopologicalNodeNumber(0) >= 0;
+        int bf = node->getTotalLocalNumberOfBasisFunctions();
+        if (isTopoNode) {
+            logger.assert_always(
+                bf == 2,
+                "Topological node with incorrect number of basis functions");
+        } else {
+            logger.assert_always(bf == 0,
+                                 "Geometric node with basis functions");
+        }
+    }
+}


### PR DESCRIPTION
Fix that the all the nodes of curvilinear elements would get conforming basis functions. The geometrical nodes (those purely for the shape) should not get basis functions, and are excluded by this PR.