### PR TITLE
Add option for epsilon of predefined structures

### DIFF
--- a/applications/DG-Max/Programs/DGMaxEigen.cpp
+++ b/applications/DG-Max/Programs/DGMaxEigen.cpp
@@ -86,6 +86,7 @@ KSpacePath<DIM> parsePath();
 
 int main(int argc, char** argv) {
     registerLogLevelCommandLineFlag();
+    DGMax::registerEpsilonCommandLineOptions();  // For predefined structures
     Base::parse_options(argc, argv);
     initDGMaxLogging();
     DGMax::printArguments(argc, argv);

--- a/applications/DG-Max/Utils/PredefinedStructure.cpp
+++ b/applications/DG-Max/Utils/PredefinedStructure.cpp
@@ -58,7 +58,7 @@ void registerEpsilonCommandLineOptions() {
 }
 
 double getEpsilonArg(double def, Base::CommandLineOption<double>* arg) {
-    if (arg == nullptr || !arg->hasArgument()) {
+    if (arg == nullptr || !arg->isUsed()) {
         return def;
     } else {
         return arg->getValue();

--- a/applications/DG-Max/Utils/PredefinedStructure.h
+++ b/applications/DG-Max/Utils/PredefinedStructure.h
@@ -74,6 +74,11 @@ class PredefinedStructureDescription : public StructureDescription {
     PredefinedStructure structure_;
     std::size_t dimension_;
 };
+
+/// Registers two command line options --epsbackground and --epsfeature
+/// that can be used to change the epsilon of the predefined structures
+void registerEpsilonCommandLineOptions();
+
 }  // namespace DGMax
 
 #endif  // HPGEM_PREDEFINEDSTRUCTURE_H


### PR DESCRIPTION
Primarily useful when using homogeneous medium, braggstack or square hole, where a structured mesh can be used.