### PR TITLE
Fix projector computation on edges

### DIFF
--- a/applications/DG-Max/Utils/KPhaseShiftHelpers.h
+++ b/applications/DG-Max/Utils/KPhaseShiftHelpers.h
@@ -95,14 +95,12 @@ template <std::size_t DIM>
 Geometry::PointPhysical<DIM> getCoordinate(const Base::Element* element,
                                            const Base::Edge* edge) {
     std::size_t localEdgeId = element->getLocalId(edge);
-    std::vector<std::size_t> nodeIds =
-        element->getReferenceGeometry()->getCodim2EntityLocalIndices(
-            localEdgeId);
-    const Geometry::PointPhysical<DIM> n1 =
-        element->getPhysicalGeometry()->getLocalNodeCoordinates(nodeIds[0]);
-    const Geometry::PointPhysical<DIM> n2 =
-        element->getPhysicalGeometry()->getLocalNodeCoordinates(nodeIds[1]);
-    return 0.5 * (n1 + n2);
+    const Geometry::ReferenceGeometry* referenceGeometry =
+        element->getReferenceGeometry();
+    Geometry::PointReference<DIM - 2> p =
+        referenceGeometry->getCodim2ReferenceGeometry(localEdgeId)->getCenter();
+    return element->referenceToPhysical(
+        referenceGeometry->getCodim2MappingPtr(localEdgeId)->transform(p));
 }
 
 /// Compute the physical coordinate of the center of a face as seen from a


### PR DESCRIPTION
The computation of the midpoint by averaging points does not work with curvalinear edges. The replacement is the correct way to compute the midpoint. I suspect that it was wrong because of either:

1. The node with index 1 may refer to the midpoint, hence taking different averages on different sides when the 0-th node is different with respect to the element (i.e. with different orientation of the edge)
2. A difference with respect to the center is computed, due to different orientations that the difference between the faux midpoint and actual midpoint gets added rather than subtracted, hence causing a shift.